### PR TITLE
Fix: add zlib to LDFLAGS for benchmarks on Linux

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -24,7 +24,7 @@ endif
 CFLAGS += -I$(AEROSPIKE)/target/$(PLATFORM)/include -I$(AEROSPIKE)/target/$(PLATFORM)/include/ck
 
 LDFLAGS = 
-LDFLAGS += -lssl -lcrypto -lpthread
+LDFLAGS += -lssl -lcrypto -lpthread -lz
 
 ifeq ($(OS),Darwin)
 LDFLAGS += -L/usr/local/lib
@@ -67,10 +67,6 @@ CFLAGS += $(LUA_CPATH:%:-I%)
 LDFLAGS += -L$(LUA_LIBDIR) -l$(LUA_LIB)
 
 LDFLAGS += -lm
-
-ifeq ($(OS),Darwin)
-LDFLAGS += -lz
-endif
 
 ifeq ($(OS),Darwin)
 CC = clang

--- a/project/test.mk
+++ b/project/test.mk
@@ -29,7 +29,7 @@ TEST_CFLAGS = -I$(TARGET_INCL)
 ifeq ($(OS),Darwin)
 TEST_LDFLAGS = -L/usr/local/lib -lssl -lcrypto -llua -lpthread -lm
 else
-TEST_LDFLAGS = -lssl -lcrypto -llua -lpthread -lm -lrt
+TEST_LDFLAGS = -lssl -lcrypto -llua -lpthread -lm -lrt -lz
 endif
 
 AS_HOST := 127.0.0.1


### PR DESCRIPTION
Tested on Ubuntu 14.04 LTS, without "-lz", we got undefined reference
errors during the linking step.