### PR TITLE
Fix bug to support POWERpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ O = 3
 # Make-local Compiler Flags
 CC_FLAGS = -std=gnu99 -g -Wall -fPIC -O$(O)
 CC_FLAGS += -fno-common -fno-strict-aliasing -finline-functions
-CC_FLAGS += -march=nocona -DMARCH_$(ARCH)
+ifeq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
+  CC_FLAGS += -DMARCH_$(ARCH)
+else
+  CC_FLAGS += -march=nocona -DMARCH_$(ARCH)
+endif
 CC_FLAGS += -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D_GNU_SOURCE $(EXT_CFLAGS)
 
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
Edited the Makefile to remove incompatible flag "-march=nocona" when the architecture is ppc64.  Thanks!