### PR TITLE
Add as_event_close_external_loops function.

### DIFF
--- a/src/include/aerospike/as_event.h
+++ b/src/include/aerospike/as_event.h
@@ -230,9 +230,22 @@ as_event_loop_get()
  *	as_event_set_external_loop_capacity() was called.
  *
  *	@ingroup async_events
+ *	@return true if the loops have been closed. In the case of external loops,
+ *	as_event_destroy_loops() must be called as soon as all the external threads
+ *	were joined.
+ */
+bool
+as_event_close_loops();
+
+
+/**
+ *	Destroy the memory managed by the aerospike library for the event loops.
+ *	This is only safe to call if as_event_close_loops returned true.
+ *
+ *	@ingroup async_events
  */
 void
-as_event_close_loops();
+as_event_destroy_loops();
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/src/main/aerospike/as_event.c
+++ b/src/main/aerospike/as_event.c
@@ -161,15 +161,14 @@ as_event_loop_find(void* loop)
 	return NULL;
 }
 
-void
+bool
 as_event_close_loops()
 {
 	if (! as_event_loops) {
-		return;
+		return true;
 	}
-	
+
 	bool status = true;
-	
 	// Close or send close signal to all event loops.
 	// This will eventually release resources associated with each event loop.
 	for (uint32_t i = 0; i < as_event_loop_size; i++) {
@@ -190,11 +189,18 @@ as_event_close_loops()
 			as_event_loop* event_loop = &as_event_loops[i];
 			pthread_join(event_loop->thread, NULL);
 		}
-		
-		cf_free(as_event_loops);
-		as_event_loops = NULL;
-		as_event_loop_size = 0;
+
+		as_event_destroy_loops();
 	}
+
+	return true;
+}
+
+void as_event_destroy_loops()
+{
+	cf_free(as_event_loops);
+	as_event_loops = NULL;
+	as_event_loop_size = 0;
 }
 
 /******************************************************************************


### PR DESCRIPTION
When an external loop is used (as_event_set_external_*loop)
as_event_close_loops does not have the capacity to wait on the threads
nor to free the memory used. Thus, when one wants to use an external
event loop, the Aerospike client is only instantiable once.
The function as_event_close_external_loops takes a pointer on a function
that is call when the events loop have been notified to exit and when
the threads should be joined so the memory can be freed and the global
reset to null.
