### PR TITLE
Break endless loop

### DIFF
--- a/src/main/aerospike/as_event.c
+++ b/src/main/aerospike/as_event.c
@@ -1002,7 +1002,9 @@ void
 as_event_notify_error(as_event_command* cmd, as_error* err)
 {
 	as_error_set_in_doubt(err, cmd->flags & AS_ASYNC_FLAGS_READ, cmd->command_sent_counter);
-
+	if (cmd->event_loop != NULL) {
+		cmd->event_loop->errors++;
+	}
 	switch (cmd->type) {
 		case AS_ASYNC_TYPE_WRITE:
 			((as_async_write_command*)cmd)->listener(err, cmd->udata, cmd->event_loop);


### PR DESCRIPTION
When occur errors, in as_event_notify_error add event_loop->errors  to break endless loop.


>$0  0x00007ffff66165d7 in vfprintf () from /lib64/libc.so.6
$1  0x00007ffff6646099 in vsnprintf () from /lib64/libc.so.6
$2  0x000000000041c620 in as_error_setallv (err=err@entry=0x7ffff4794580, code=code@entry=AEROSPIKE_ERR_INVALID_NODE, 
    func=func@entry=0x46db10 <__func__.15023> "as_event_command_begin", file=0x46d74c "src/main/aerospike/as_event.c", line=line@entry=530, 
    fmt=fmt@entry=0x46d918 "Node not found for partition %s", file=0x46d74c "src/main/aerospike/as_event.c") at src/include/aerospike/as_error.h:232
$3  0x000000000041e9a4 in as_event_command_begin (cmd=cmd@entry=0x7ffff0245a60, event_loop=0x696070, event_loop=0x696070)
    at src/main/aerospike/as_event.c:529
$4  0x000000000041ec82 in as_event_command_execute_in_loop (event_loop=event_loop@entry=0x696070, cmd=cmd@entry=0x7ffff0245a60)
    at src/main/aerospike/as_event.c:472
$5  0x000000000041447c in as_event_command_execute (err=0x7ffff4794fc0, cmd=0x7ffff0245a60) at src/include/aerospike/as_event_internal.h:675
$6  aerospike_key_put_async_ex (as=as@entry=0x7fffffffd168, err=0x7ffff4794fc0, policy=0x7fffffffd280, policy@entry=0x0, key=key@entry=0x6d6878, 
    rec=rec@entry=0x6d6920, listener=listener@entry=0x40b6df <random_write_listener>, udata=udata@entry=0x6d6840, event_loop=event_loop@entry=0x696070, 
    pipe_listener=pipe_listener@entry=0x0, length=length@entry=0x0, comp_length=comp_length@entry=0x0) at src/main/aerospike/aerospike_key.c:664
$7  0x00000000004144eb in aerospike_key_put_async (as=as@entry=0x7fffffffd168, err=<optimized out>, policy=policy@entry=0x0, key=key@entry=0x6d6878, 
    rec=rec@entry=0x6d6920, listener=listener@entry=0x40b6df <random_write_listener>, udata=udata@entry=0x6d6840, event_loop=event_loop@entry=0x696070, 
    pipe_listener=pipe_listener@entry=0x0) at src/main/aerospike/aerospike_key.c:709
$8  0x000000000040b469 in random_read_write_async (cdata=cdata@entry=0x7fffffffd120, tdata=tdata@entry=0x6d6840, event_loop=event_loop@entry=0x696070)
    at src/main/record.c:613
$9  0x000000000040b784 in random_read_write_next (event_loop=0x696070, tdata=0x6d6840, cdata=0x7fffffffd120) at src/main/record.c:626
$10 random_write_listener (err=<optimized out>, udata=0x6d6840, event_loop=0x696070) at src/main/record.c:665
$11 0x000000000041d4b3 in as_event_notify_error (cmd=cmd@entry=0x7ffff0245650, err=err@entry=0x7ffff47954a0) at src/main/aerospike/as_event.c:1010
$12 0x000000000041e866 in as_event_error_callback (err=0x7ffff47954a0, cmd=0x7ffff0245650) at src/include/aerospike/as_event_internal.h:819
$13 as_event_command_begin (cmd=cmd@entry=0x7ffff0245650, event_loop=0x696070, event_loop=0x696070) at src/main/aerospike/as_event.c:593
$14 0x000000000041ec82 in as_event_command_execute_in_loop (event_loop=event_loop@entry=0x696070, cmd=cmd@entry=0x7ffff0245650)
    at src/main/aerospike/as_event.c:472
$15 0x000000000041447c in as_event_command_execute (err=0x7ffff4795ee0, cmd=0x7ffff0245650) at src/include/aerospike/as_event_internal.h:675
$16 aerospike_key_put_async_ex (as=as@entry=0x7fffffffd168, err=0x7ffff4795ee0, policy=0x7fffffffd280, policy@entry=0x0, key=key@entry=0x6d6878, 
    rec=rec@entry=0x6d6920, listener=listener@entry=0x40b6df <random_write_listener>, udata=udata@entry=0x6d6840, event_loop=event_loop@entry=0x696070, 
    pipe_listener=pipe_listener@entry=0x0, length=length@entry=0x0, comp_length=comp_length@entry=0x0) at src/main/aerospike/aerospike_key.c:664
$17 0x00000000004144eb in aerospike_key_put_async (as=as@entry=0x7fffffffd168, err=<optimized out>, policy=policy@entry=0x0, key=key@entry=0x6d6878, 
    rec=rec@entry=0x6d6920, listener=listener@entry=0x40b6df <random_write_listener>, udata=udata@entry=0x6d6840, event_loop=event_loop@entry=0x696070, 
    pipe_listener=pipe_listener@entry=0x0) at src/main/aerospike/aerospike_key.c:709
---Type <return> to continue, or q <return> to quit---
$18 0x000000000040b469 in random_read_write_async (cdata=cdata@entry=0x7fffffffd120, tdata=tdata@entry=0x6d6840, event_loop=event_loop@entry=0x696070)
    at src/main/record.c:613