### PR TITLE
[PROD-1369] added --compress option to benchmark

### DIFF
--- a/benchmarks/src/main/benchmark.c
+++ b/benchmarks/src/main/benchmark.c
@@ -129,7 +129,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->read.base.socket_timeout = args->read_socket_timeout;
 	p->read.base.total_timeout = args->read_total_timeout;
 	p->read.base.max_retries = args->max_retries;
-    p->read.base.compress = args->enable_compression;
+	p->read.base.compress = args->enable_compression;
 	p->read.replica = args->replica;
 	p->read.read_mode_ap = args->read_mode_ap;
 	p->read.read_mode_sc = args->read_mode_sc;
@@ -137,7 +137,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->write.base.socket_timeout = args->write_socket_timeout;
 	p->write.base.total_timeout = args->write_total_timeout;
 	p->write.base.max_retries = args->max_retries;
-    p->write.base.compress = args->enable_compression;
+	p->write.base.compress = args->enable_compression;
 	p->write.replica = args->replica;
 	p->write.commit_level = args->write_commit_level;
 	p->write.durable_delete = args->durable_deletes;
@@ -145,7 +145,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->operate.base.socket_timeout = args->write_socket_timeout;
 	p->operate.base.total_timeout = args->write_total_timeout;
 	p->operate.base.max_retries = args->max_retries;
-    p->operate.base.compress = args->enable_compression;
+	p->operate.base.compress = args->enable_compression;
 	p->operate.replica = args->replica;
 	p->operate.commit_level = args->write_commit_level;
 	p->operate.durable_delete = args->durable_deletes;
@@ -155,7 +155,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->remove.base.socket_timeout = args->write_socket_timeout;
 	p->remove.base.total_timeout = args->write_total_timeout;
 	p->remove.base.max_retries = args->max_retries;
-    p->remove.base.compress = args->enable_compression;
+	p->remove.base.compress = args->enable_compression;
 	p->remove.replica = args->replica;
 	p->remove.commit_level = args->write_commit_level;
 	p->remove.durable_delete = args->durable_deletes;
@@ -163,7 +163,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->batch.base.socket_timeout = args->read_socket_timeout;
 	p->batch.base.total_timeout = args->read_total_timeout;
 	p->batch.base.max_retries = args->max_retries;
-    p->batch.base.compress = args->enable_compression;
+	p->batch.base.compress = args->enable_compression;
 	p->batch.replica = args->replica;
 	p->batch.read_mode_ap = args->read_mode_ap;
 	p->batch.read_mode_sc = args->read_mode_sc;

--- a/benchmarks/src/main/benchmark.c
+++ b/benchmarks/src/main/benchmark.c
@@ -129,6 +129,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->read.base.socket_timeout = args->read_socket_timeout;
 	p->read.base.total_timeout = args->read_total_timeout;
 	p->read.base.max_retries = args->max_retries;
+    p->read.base.compress = args->enable_compression;
 	p->read.replica = args->replica;
 	p->read.read_mode_ap = args->read_mode_ap;
 	p->read.read_mode_sc = args->read_mode_sc;
@@ -136,6 +137,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->write.base.socket_timeout = args->write_socket_timeout;
 	p->write.base.total_timeout = args->write_total_timeout;
 	p->write.base.max_retries = args->max_retries;
+    p->write.base.compress = args->enable_compression;
 	p->write.replica = args->replica;
 	p->write.commit_level = args->write_commit_level;
 	p->write.durable_delete = args->durable_deletes;
@@ -143,6 +145,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->operate.base.socket_timeout = args->write_socket_timeout;
 	p->operate.base.total_timeout = args->write_total_timeout;
 	p->operate.base.max_retries = args->max_retries;
+    p->operate.base.compress = args->enable_compression;
 	p->operate.replica = args->replica;
 	p->operate.commit_level = args->write_commit_level;
 	p->operate.durable_delete = args->durable_deletes;
@@ -152,6 +155,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->remove.base.socket_timeout = args->write_socket_timeout;
 	p->remove.base.total_timeout = args->write_total_timeout;
 	p->remove.base.max_retries = args->max_retries;
+    p->remove.base.compress = args->enable_compression;
 	p->remove.replica = args->replica;
 	p->remove.commit_level = args->write_commit_level;
 	p->remove.durable_delete = args->durable_deletes;
@@ -159,6 +163,7 @@ connect_to_server(arguments* args, aerospike* client)
 	p->batch.base.socket_timeout = args->read_socket_timeout;
 	p->batch.base.total_timeout = args->read_total_timeout;
 	p->batch.base.max_retries = args->max_retries;
+    p->batch.base.compress = args->enable_compression;
 	p->batch.replica = args->replica;
 	p->batch.read_mode_ap = args->read_mode_ap;
 	p->batch.read_mode_sc = args->read_mode_sc;

--- a/benchmarks/src/main/benchmark.h
+++ b/benchmarks/src/main/benchmark.h
@@ -56,6 +56,7 @@ typedef struct arguments_t {
 	int threads;
 	int throughput;
 	int batch_size;
+	bool enable_compression;
 	int read_socket_timeout;
 	int write_socket_timeout;
 	int read_total_timeout;

--- a/benchmarks/src/main/main.c
+++ b/benchmarks/src/main/main.c
@@ -49,9 +49,10 @@ static struct option long_options[] = {
 	{"threads",              required_argument, 0, 'z'},
 	{"throughput",           required_argument, 0, 'g'},
 	{"batchSize",            required_argument, 0, '0'},
-	{"socketTimeout",        required_argument, 0, '1'},
-	{"readSocketTimeout",    required_argument, 0, '2'},
-	{"writeSocketTimeout",   required_argument, 0, '3'},
+	{"compress",             no_argument,       0, '1'},
+	{"socketTimeout",        required_argument, 0, '2'},
+	{"readSocketTimeout",    required_argument, 0, '3'},
+	{"writeSocketTimeout",   required_argument, 0, '4'},
 	{"timeout",              required_argument, 0, 'T'},
 	{"readTimeout",          required_argument, 0, 'X'},
 	{"writeTimeout",         required_argument, 0, 'V'},
@@ -182,9 +183,14 @@ print_usage(const char* program)
 	blog_line("   Used in read/write mode only.");
 	blog_line("");
 
-	blog_line("--batchSize <size> # Default: 0");
+	blog_line("   --batchSize <size> # Default: 0");
 	blog_line("   Enable batch mode with number of records to process in each batch get call.");
 	blog_line("   Batch mode is valid only for RU (read update) workloads. Batch mode is disabled by default.");
+	blog_line("");
+
+	blog_line("   --compress");
+	blog_line("   Enable binary data compression through the aerospike client.");
+	blog_line("   Internally, this sets the compression policy to true.");
 	blog_line("");
 
 	blog_line("   --socketTimeout <ms> # Default: 30000");
@@ -415,6 +421,7 @@ print_args(arguments* args)
 	}
 
 	blog_line("batch size:             %d", args->batch_size);
+	blog_line("enable compression:     %s", boolstring(args->enable_compression));
 	blog_line("read socket timeout:    %d ms", args->read_socket_timeout);
 	blog_line("write socket timeout:   %d ms", args->write_socket_timeout);
 	blog_line("read total timeout:     %d ms", args->read_total_timeout);
@@ -736,15 +743,19 @@ set_args(int argc, char * const * argv, arguments* args)
 				break;
 
 			case '1':
-				args->read_socket_timeout = atoi(optarg);
-				args->write_socket_timeout = args->read_socket_timeout;
+                args->enable_compression = true;
 				break;
 
 			case '2':
 				args->read_socket_timeout = atoi(optarg);
+				args->write_socket_timeout = args->read_socket_timeout;
 				break;
 
 			case '3':
+				args->read_socket_timeout = atoi(optarg);
+				break;
+
+			case '4':
 				args->write_socket_timeout = atoi(optarg);
 				break;
 
@@ -960,6 +971,7 @@ main(int argc, char * const * argv)
 	args.threads = 16;
 	args.throughput = 0;
 	args.batch_size = 0;
+	args.enable_compression = false;
 	args.read_socket_timeout = AS_POLICY_SOCKET_TIMEOUT_DEFAULT;
 	args.write_socket_timeout = AS_POLICY_SOCKET_TIMEOUT_DEFAULT;
 	args.read_total_timeout = AS_POLICY_TOTAL_TIMEOUT_DEFAULT;

--- a/benchmarks/src/main/main.c
+++ b/benchmarks/src/main/main.c
@@ -743,7 +743,7 @@ set_args(int argc, char * const * argv, arguments* args)
 				break;
 
 			case '1':
-                args->enable_compression = true;
+				args->enable_compression = true;
 				break;
 
 			case '2':


### PR DESCRIPTION
Only required a tiny modification to the code, essentially add the flag to the arg struct and then set the compress field in the as_policy_base field of the as_policy_* structs in connect_to_server.