### PR TITLE
Fixing thread safety issue on shutdown

### DIFF
--- a/src/main/aerospike/as_cluster.c
+++ b/src/main/aerospike/as_cluster.c
@@ -1346,11 +1346,11 @@ void
 as_cluster_destroy(as_cluster* cluster)
 {
 	// Stop tend thread and wait till finished.
+	pthread_mutex_lock(&cluster->tend_lock);
 	if (cluster->valid) {
 		cluster->valid = false;
 		
 		// Signal tend thread to wake up from sleep and stop.
-		pthread_mutex_lock(&cluster->tend_lock);
 		pthread_cond_signal(&cluster->tend_cond);
 		pthread_mutex_unlock(&cluster->tend_lock);
 		
@@ -1360,6 +1360,8 @@ as_cluster_destroy(as_cluster* cluster)
 		if (cluster->shm_info) {
 			as_shm_destroy(cluster);
 		}
+	} else {
+		pthread_mutex_unlock(&cluster->tend_lock);
 	}
 
 	// Shutdown thread pool.


### PR DESCRIPTION
Found with thread sanitizer so I'm not 100% sure this will hit in the real world. The idea is the write for the bool cluster->valid is not guarded. The check here is guarded https://github.com/aerospike/aerospike-client-c/blob/master/src/main/aerospike/as_shm_cluster.c#L802 but the bool is not guarded on destory.