### PR TITLE
Client 4343 name change: as_exp_result_remove -> as_exp_remove_result

### DIFF
--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -127,7 +127,6 @@ typedef enum {
 	_AS_EXP_CODE_BIN_TYPE = 82,
 
 	_AS_EXP_CODE_REMOVE_RESULT = 100,
-	_AS_EXP_CODE_RESULT_REMOVE = 100,	// deprecated
 
 	_AS_EXP_CODE_LOOPVAR = 122,
 

--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -126,7 +126,8 @@ typedef enum {
 	_AS_EXP_CODE_BIN = 81,
 	_AS_EXP_CODE_BIN_TYPE = 82,
 
-	_AS_EXP_CODE_RESULT_REMOVE = 100,
+	_AS_EXP_CODE_REMOVE_RESULT = 100,
+	_AS_EXP_CODE_RESULT_REMOVE = 100,	// deprecated
 
 	_AS_EXP_CODE_LOOPVAR = 122,
 
@@ -1754,11 +1755,21 @@ as_exp_destroy_base64(char* base64)
 		_as_exp_loopvar_make(__var_id, HLL)
 
 /**
- * Return a result_remove object to indicate entry deletion for cdt_apply.
- * @return the result_remove value.
+ * Return a remove_result object to indicate entry deletion for cdt_apply.
+ * @return the remove_result value.
  * @ingroup expression
  */
-#define as_exp_result_remove() {.op=_AS_EXP_CODE_RESULT_REMOVE, .count=1}
+#define as_exp_remove_result() {.op=_AS_EXP_CODE_REMOVE_RESULT, .count=1}
+
+/**
+ * Return a remove_result object to indicate entry deletion for cdt_apply.
+ * This name is deprecated; please use as_exp_remove_result() going forward.
+ *
+ * @return the remove_result value.
+ * @ingroup expression
+ * @see as_exp_remove_result()
+ */
+#define as_exp_result_remove() as_exp_remove_result()
 
 //---------------------------------
 // List Modify Expressions

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -3746,7 +3746,7 @@ TEST(list_apply_remove, "test select apply remove")
 	as_cdt_ctx_add_all_children_with_filter(&ctx, price_check_exp);
 
 	as_exp_build(exp,
-		as_exp_result_remove());
+		as_exp_remove_result());
 	assert_not_null(exp);
 
 	as_operations ops;
@@ -3853,7 +3853,7 @@ TEST(list_apply_remove2, "test select apply remove 2")
 	as_cdt_ctx_add_all_children_with_filter(&ctx, price_check_exp);
 
 	as_exp_build(exp,
-		as_exp_result_remove());
+		as_exp_remove_result());
 	assert_not_null(exp);
 
 	as_operations ops;


### PR DESCRIPTION
Andrew Kim opened this ticket (client-4343) to request a name-change for greater API consistency, especially between clients.  This PR applies the changes needed to satisfy this request in a way that does not break existing clients.