### PR TITLE
CLIENT-4388: Remove unused APPLY flag

### DIFF
--- a/src/include/aerospike/as_operations.h
+++ b/src/include/aerospike/as_operations.h
@@ -363,12 +363,6 @@ typedef enum {
 	AS_EXP_PATH_MODIFY_DEFAULT = 0x00,
 
 	/**
-	 * @private
-	 * This flag is set when leaf values are to be modified.
-	 */
-	AS_EXP_PATH_MODIFY_APPLY = 0x04,
-
-	/**
 	 * If the expression in the context hits an invalid type (e.g., selects
 	 * as an integer when the value is a string), do not fail the operation;
 	 * just ignore those elements.  Interpret UNKNOWN as false instead.


### PR DESCRIPTION
This flag is unused in the source code, and is intended to be (and was marked via @private tag in Doxygen docs) private.

The flag was originally introduced to eliminate the use of a magic constant in the source code.  However, after several merges and rebases, the only two usage sites were reverted back to using the magic constant, leaving the flag unused.  Per Andrew Kim, this flag somehow appeared in public-facing documentation, which raised the initial concern of whether it was necessary in the first place.

Therefore, after some discussion on Slack, it was decided to just remove the flag entirely.  This flag removes the flag.