### PR TITLE
Client 4433 enhanced expressions p1

### DIFF
--- a/src/include/aerospike/as_cdt_ctx.h
+++ b/src/include/aerospike/as_cdt_ctx.h
@@ -45,7 +45,8 @@ typedef enum {
 	AS_CDT_CTX_MAP_INDEX = 0x20,
 	AS_CDT_CTX_MAP_RANK = 0x21,
 	AS_CDT_CTX_MAP_KEY = 0x22,
-	AS_CDT_CTX_MAP_VALUE = 0x23
+	AS_CDT_CTX_MAP_VALUE = 0x23,
+	AS_CDT_CTX_MAP_KEYS_IN = 0x2A,
 } as_cdt_ctx_type;
 
 /**
@@ -334,6 +335,21 @@ as_cdt_ctx_add_map_value(as_cdt_ctx* ctx, as_val* val)
 	as_cdt_ctx_item item;
 	item.type = AS_CDT_CTX_MAP_VALUE;
 	item.val.pval = val;
+	as_vector_append(&ctx->list, &item);
+}
+
+/**
+ * Lookup one or more keys in a map.
+ * 
+ * @relates as_operations
+ * @ingroup base_operations
+ */
+static inline void
+as_cdt_ctx_add_map_keys_in(as_cdt_ctx* ctx, as_val* keys)
+{
+	as_cdt_ctx_item item;
+	item.type = AS_CDT_CTX_MAP_KEYS_IN;
+	item.val.pval = keys;
 	as_vector_append(&ctx->list, &item);
 }
 

--- a/src/include/aerospike/as_cdt_ctx.h
+++ b/src/include/aerospike/as_cdt_ctx.h
@@ -28,6 +28,8 @@ extern "C" {
 // Types
 //---------------------------------
 
+typedef struct as_list as_list;
+
 /**
  * Nested CDT context type.
  *
@@ -339,17 +341,24 @@ as_cdt_ctx_add_map_value(as_cdt_ctx* ctx, as_val* val)
 }
 
 /**
- * Lookup one or more keys in a map.
- * 
+ * Restrict map context to the given list of keys, provided they exist.
+ *
+ * For example, if a map {"A": 1, "B": 2, "C": 3} exists, and you pass
+ * keys ["A", "C", "D"] in as the list of keys, the result will only
+ * include ["A", "C"], since element "D" does not exist in the map.
+ * Observe that the values of the corresponding keys are not returned.
+ *
+ * The ctx list takes ownership of keys.
+ *
  * @relates as_operations
  * @ingroup base_operations
  */
 static inline void
-as_cdt_ctx_add_map_keys_in(as_cdt_ctx* ctx, as_val* keys)
+as_cdt_ctx_add_map_keys_in(as_cdt_ctx* ctx, as_list* keys)
 {
 	as_cdt_ctx_item item;
 	item.type = AS_CDT_CTX_MAP_KEYS_IN;
-	item.val.pval = keys;
+	item.val.pval = (as_val*)keys;
 	as_vector_append(&ctx->list, &item);
 }
 

--- a/src/include/aerospike/as_cdt_ctx.h
+++ b/src/include/aerospike/as_cdt_ctx.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <aerospike/as_cdt_order.h>
+#include <aerospike/as_list.h>
 #include <aerospike/as_vector.h>
 #include <aerospike/as_val.h>
 
@@ -28,13 +29,14 @@ extern "C" {
 // Types
 //---------------------------------
 
-typedef struct as_list as_list;
-
 /**
  * Nested CDT context type.
  *
  * Note that AS_CDT_CTX_VALUE is a flag (currently, bit 1) within each of the
  * enumeration variants, indicating which variants are to be considered values.
+ *
+ * AS_CDT_CTX_AND is combined with AS_CDT_CTX_EXP for an additional boolean
+ * filter at the current context level (wire ID 0x0204).
  *
  * @relates as_operations
  * @ingroup base_operations
@@ -55,6 +57,13 @@ typedef enum {
  * Flag indicating whether or not a AS_CDT_CTX_xxx variant is a value.
  */
 #define AS_CDT_CTX_VALUE 0x2
+
+/**
+ * Modifier for expression context items: AND-combine a filter with the
+ * already-narrowed context (see as_cdt_ctx_add_and_filter()).
+ * Wire type is (AS_CDT_CTX_AND | AS_CDT_CTX_EXP) (0x0204).
+ */
+#define AS_CDT_CTX_AND 0x200
 
 /**
  * Nested CDT context level.
@@ -389,6 +398,19 @@ as_cdt_ctx_add_all_children(as_cdt_ctx* ctx);
  */
 AS_EXTERN void
 as_cdt_ctx_add_all_children_with_filter(as_cdt_ctx* ctx, const struct as_exp* exp);
+
+/**
+ * Add a boolean expression filter AND-combined with the current context.
+ *
+ * The ctx does NOT take ownership of exp. Evaluation runs after prior context
+ * steps (e.g. map key-list selection); entries must satisfy both. Multiple
+ * as_cdt_ctx_add_and_filter() calls may be chained.
+ *
+ * @relates as_operations
+ * @ingroup base_operations
+ */
+AS_EXTERN void
+as_cdt_ctx_add_and_filter(as_cdt_ctx* ctx, const struct as_exp* exp);
 
 /**
  * Return exact serialized size of ctx. Return zero on error.

--- a/src/include/aerospike/as_cdt_ctx.h
+++ b/src/include/aerospike/as_cdt_ctx.h
@@ -354,13 +354,14 @@ as_cdt_ctx_add_map_value(as_cdt_ctx* ctx, as_val* val)
  *
  * For example, if a map {"A": 1, "B": 2, "C": 3} exists, and you pass
  * keys ["A", "C", "D"] in as the list of keys, the result will only
- * include ["A", "C"], since element "D" does not exist in the map.
+ * include {"A": 1, "C": 3}, since element "D" does not exist in the map.
  * Observe that the values of the corresponding keys are not returned.
  *
  * The ctx list takes ownership of keys.
  *
  * @relates as_operations
  * @ingroup base_operations
+ * @see as_cdt_ctx_add_and_filter
  */
 static inline void
 as_cdt_ctx_add_map_keys_in(as_cdt_ctx* ctx, as_list* keys)
@@ -408,6 +409,7 @@ as_cdt_ctx_add_all_children_with_filter(as_cdt_ctx* ctx, const struct as_exp* ex
  *
  * @relates as_operations
  * @ingroup base_operations
+ * @see as_cdt_ctx_add_map_keys_in
  */
 AS_EXTERN void
 as_cdt_ctx_add_and_filter(as_cdt_ctx* ctx, const struct as_exp* exp);

--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -128,6 +128,8 @@ typedef enum {
 	_AS_EXP_CODE_BIN_TYPE = 82,
 
 	_AS_EXP_CODE_REMOVE_RESULT = 100,
+	_AS_EXP_CODE_MAP_KEYS = 101,
+	_AS_EXP_CODE_MAP_VALUES = 102,
 
 	_AS_EXP_CODE_LOOPVAR = 122,
 
@@ -971,6 +973,43 @@ as_exp_destroy_base64(char* base64)
  */
 #define as_exp_in_list(__left, __list) \
 		{.op=_AS_EXP_CODE_IN_LIST, .count=3}, __left, as_exp_val((as_val*)(__list))
+
+/**
+ * Return a list of keys from a map-valued subexpression.
+ *
+ * @a __map must evaluate to a map, for example @c as_exp_bin_map("name") for a
+ * map bin, or @c as_exp_val((as_val*)m) for a literal @c as_map / @c as_orderedmap.
+ * Literal maps are serialized at compile time; the caller retains ownership and
+ * should destroy them after @c as_exp_build.
+ *
+ * @code
+ * as_orderedmap m;
+ * as_orderedmap_init(&m, 2);
+ * as_orderedmap_set(&m, (as_val*)as_string_new((char*)"k", false),
+ *     (as_val*)as_integer_new(1));
+ * as_exp_build(e, as_exp_map_keys(as_exp_val((as_val*)&m)));
+ * as_exp_destroy(e);
+ * as_orderedmap_destroy(&m);
+ * @endcode
+ *
+ * @param __map	Map-valued expression (e.g. bin or constant).
+ * @return (list value)
+ * @ingroup expression
+ */
+#define as_exp_map_keys(__map) \
+		{.op=_AS_EXP_CODE_MAP_KEYS, .count=2}, __map
+
+/**
+ * Return a list of values from a map-valued subexpression.
+ *
+ * @a __map must evaluate to a map; see @ref as_exp_map_keys for operand forms.
+ *
+ * @param __map	Map-valued expression (e.g. bin or constant).
+ * @return (list value)
+ * @ingroup expression
+ */
+#define as_exp_map_values(__map) \
+		{.op=_AS_EXP_CODE_MAP_VALUES, .count=2}, __map
 
 /**
  * Create expression that performs a regex match on a string bin or value

--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -76,6 +76,7 @@ typedef enum {
 
 	_AS_EXP_CODE_CMP_REGEX = 7,
 	_AS_EXP_CODE_CMP_GEO = 8,
+	_AS_EXP_CODE_IN_LIST = 9,
 
 	_AS_EXP_CODE_AND = 16,
 	_AS_EXP_CODE_OR = 17,
@@ -947,6 +948,29 @@ as_exp_destroy_base64(char* base64)
  */
 #define as_exp_cmp_le(__left, __right) \
 		{.op=_AS_EXP_CODE_CMP_LE, .count=3}, __left, __right
+
+/**
+ * True if the value of @a __left is contained in @a __list (by value).
+ *
+ * @a __left may be any expression. @a __list must be an @c as_list (for example
+ * @c as_arraylist). The list is serialized when the expression is compiled; the
+ * caller retains ownership of @a __list and should destroy it after @c as_exp_build.
+ *
+ * @code
+ * as_arraylist* lst = as_arraylist_new(3, 3);
+ * as_arraylist_append_str(lst, "red");
+ * as_arraylist_append_str(lst, "blue");
+ * as_exp_build(e, as_exp_in_list(as_exp_bin_str("color"), lst));
+ * as_arraylist_destroy(lst);
+ * @endcode
+ *
+ * @param __left	Value expression to test for membership.
+ * @param __list	List of values to search (must not be NULL).
+ * @return (boolean value)
+ * @ingroup expression
+ */
+#define as_exp_in_list(__left, __list) \
+		{.op=_AS_EXP_CODE_IN_LIST, .count=3}, __left, as_exp_val((as_val*)(__list))
 
 /**
  * Create expression that performs a regex match on a string bin or value

--- a/src/main/aerospike/as_cdt_ctx.c
+++ b/src/main/aerospike/as_cdt_ctx.c
@@ -37,7 +37,7 @@ as_cdt_ctx_destroy(as_cdt_ctx* ctx)
 		if (item->type & AS_CDT_CTX_VALUE) {
 			as_val_destroy(item->val.pval);
 		}
-		else if (item->type == AS_CDT_CTX_EXP) {
+		else if ((item->type & ~AS_CDT_CTX_AND) == AS_CDT_CTX_EXP) {
 			cf_free(item->val.exp);
 		}
 	}
@@ -61,6 +61,17 @@ as_cdt_ctx_add_all_children_with_filter(as_cdt_ctx* ctx, const as_exp* exp)
 {
 	as_cdt_ctx_item item;
 	item.type = AS_CDT_CTX_EXP;
+	as_exp* new_exp = cf_malloc(sizeof(as_exp) + exp->packed_sz);
+	memcpy(new_exp, exp, sizeof(as_exp) + exp->packed_sz);
+	item.val.exp = new_exp;
+	as_vector_append(&ctx->list, &item);
+}
+
+void
+as_cdt_ctx_add_and_filter(as_cdt_ctx* ctx, const as_exp* exp)
+{
+	as_cdt_ctx_item item;
+	item.type = AS_CDT_CTX_AND | AS_CDT_CTX_EXP;
 	as_exp* new_exp = cf_malloc(sizeof(as_exp) + exp->packed_sz);
 	memcpy(new_exp, exp, sizeof(as_exp) + exp->packed_sz);
 	item.val.exp = new_exp;

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -95,7 +95,7 @@ as_cdt_ctx_pack(const as_cdt_ctx* ctx, as_packer* pk)
 			return 0;
 		}
 
-		if (item->type == AS_CDT_CTX_EXP) {
+		if ((item->type & ~AS_CDT_CTX_AND) == AS_CDT_CTX_EXP) {
 			if (as_pack_append(pk,
 					item->val.exp->packed, item->val.exp->packed_sz) != 0) {
 				return 0;

--- a/src/test/aerospike_map/map_basics.c
+++ b/src/test/aerospike_map/map_basics.c
@@ -1941,7 +1941,7 @@ TEST(map_nested, "Nested Map")
 	as_record_destroy(prec);
 }
 
-TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key list")
+TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with path select")
 {
 	as_key rkey;
 	as_key_init_int64(&rkey, NAMESPACE, SET, 92);
@@ -2018,18 +2018,10 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_cdt_ctx_add_map_key(&ctx, (as_val*)&k2);
 	as_cdt_ctx_add_map_keys_in(&ctx, (as_list*)keys_in);
 
-	// This list of keys is used by the as_operations_map_get_by_key_list()
-	// function, below.
-
-	as_arraylist* query_keys = as_arraylist_new(2, 2);
-	assert_not_null(query_keys);
-	as_arraylist_append_str(query_keys, "key21");
-	as_arraylist_append_str(query_keys, "key23");
-
 	as_operations ops;
 	as_operations_inita(&ops, 1);
-	assert_true(as_operations_map_get_by_key_list(
-			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_KEY));
+	assert_int_eq(as_operations_select_by_path(&err, &ops, BIN_NAME, &ctx,
+			AS_EXP_PATH_SELECT_MAP_KEY), AEROSPIKE_OK);
 
 	as_record* prec = NULL;
 	status = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &prec);
@@ -2047,7 +2039,7 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_record_destroy(prec);
 }
 
-TEST(map_keys_in_and_filter, "MAP_KEYS_IN with AND expression filter on map get by key list")
+TEST(map_keys_in_and_filter, "MAP_KEYS_IN with AND expression filter on path select")
 {
 	as_key rkey;
 	as_key_init_int64(&rkey, NAMESPACE, SET, 93);
@@ -2103,15 +2095,10 @@ TEST(map_keys_in_and_filter, "MAP_KEYS_IN with AND expression filter on map get 
 	as_cdt_ctx_add_map_keys_in(&ctx, (as_list*)keys_in);
 	as_cdt_ctx_add_and_filter(&ctx, af);
 
-	as_arraylist* query_keys = as_arraylist_new(2, 2);
-	assert_not_null(query_keys);
-	as_arraylist_append_str(query_keys, "a");
-	as_arraylist_append_str(query_keys, "c");
-
 	as_operations ops;
 	as_operations_inita(&ops, 1);
-	assert_true(as_operations_map_get_by_key_list(
-			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_UNORDERED_MAP));
+	assert_int_eq(as_operations_select_by_path(&err, &ops, BIN_NAME, &ctx,
+			AS_EXP_PATH_SELECT_MATCHING_TREE), AEROSPIKE_OK);
 
 	as_record* prec = NULL;
 	status = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &prec);

--- a/src/test/aerospike_map/map_basics.c
+++ b/src/test/aerospike_map/map_basics.c
@@ -1950,6 +1950,13 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_status status = aerospike_key_remove(as, &err, NULL, &rkey);
 	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
 
+	// Construct a nested map:
+	//
+	// {
+	//     'key1': { 'key11': 9, 'key12': 4 },
+	//     'key2': { 'key21': 3, 'key22': 5, 'key23': 7 },
+	// }
+
 	as_hashmap m1;
 	as_hashmap_init(&m1, 2);
 	as_string k11;
@@ -1998,6 +2005,8 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	assert_int_eq(status, AEROSPIKE_OK);
 	as_record_destroy(&rec);
 
+	// Create list of keys to query for in context query
+
 	as_arraylist* keys_in = as_arraylist_new(2, 2);
 	assert_not_null(keys_in);
 	as_arraylist_append_str(keys_in, "key21");
@@ -2009,6 +2018,9 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_cdt_ctx_add_map_key(&ctx, (as_val*)&k2);
 	as_cdt_ctx_add_map_keys_in(&ctx, (as_val*)keys_in);
 
+	// This list of keys is used by the as_operations_map_get_by_key_list()
+	// function, below.
+
 	as_arraylist* query_keys = as_arraylist_new(2, 2);
 	assert_not_null(query_keys);
 	as_arraylist_append_str(query_keys, "key21");
@@ -2017,7 +2029,7 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_operations ops;
 	as_operations_inita(&ops, 1);
 	assert_true(as_operations_map_get_by_key_list(
-			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_KEY_VALUE));
+			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_KEY));
 
 	as_record* prec = NULL;
 	status = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &prec);
@@ -2028,11 +2040,9 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	assert_not_null(prec);
 	as_bin* results = prec->bins.entries;
 	as_list* list = &results[0].valuep->list;
-	assert_int_eq(as_list_size(list), 2 * 2);
-	assert_string_eq(as_list_get_str(list, 0 * 2), "key21");
-	assert_int_eq(as_list_get_int64(list, 0 * 2 + 1), 3);
-	assert_string_eq(as_list_get_str(list, 1 * 2), "key23");
-	assert_int_eq(as_list_get_int64(list, 1 * 2 + 1), 7);
+	assert_int_eq(as_list_size(list), 2);
+	assert_string_eq(as_list_get_str(list, 0), "key21");
+	assert_string_eq(as_list_get_str(list, 1), "key23");
 
 	as_record_destroy(prec);
 }

--- a/src/test/aerospike_map/map_basics.c
+++ b/src/test/aerospike_map/map_basics.c
@@ -2016,7 +2016,7 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_cdt_ctx_inita(&ctx, 2);
 	as_string_init(&k2, "key2", false);
 	as_cdt_ctx_add_map_key(&ctx, (as_val*)&k2);
-	as_cdt_ctx_add_map_keys_in(&ctx, (as_val*)keys_in);
+	as_cdt_ctx_add_map_keys_in(&ctx, (as_list*)keys_in);
 
 	// This list of keys is used by the as_operations_map_get_by_key_list()
 	// function, below.

--- a/src/test/aerospike_map/map_basics.c
+++ b/src/test/aerospike_map/map_basics.c
@@ -1941,6 +1941,102 @@ TEST(map_nested, "Nested Map")
 	as_record_destroy(prec);
 }
 
+TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key list")
+{
+	as_key rkey;
+	as_key_init_int64(&rkey, NAMESPACE, SET, 92);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &rkey);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_hashmap m1;
+	as_hashmap_init(&m1, 2);
+	as_string k11;
+	as_string_init(&k11, "key11", false);
+	as_integer v11;
+	as_integer_init(&v11, 9);
+	as_hashmap_set(&m1, (as_val*)&k11, (as_val*)&v11);
+	as_string k12;
+	as_string_init(&k12, "key12", false);
+	as_integer v12;
+	as_integer_init(&v12, 4);
+	as_hashmap_set(&m1, (as_val*)&k12, (as_val*)&v12);
+
+	as_hashmap m2;
+	as_hashmap_init(&m2, 3);
+	as_string k21;
+	as_string_init(&k21, "key21", false);
+	as_integer v21;
+	as_integer_init(&v21, 3);
+	as_hashmap_set(&m2, (as_val*)&k21, (as_val*)&v21);
+	as_string k22;
+	as_string_init(&k22, "key22", false);
+	as_integer v22;
+	as_integer_init(&v22, 5);
+	as_hashmap_set(&m2, (as_val*)&k22, (as_val*)&v22);
+	as_string k23;
+	as_string_init(&k23, "key23", false);
+	as_integer v23;
+	as_integer_init(&v23, 7);
+	as_hashmap_set(&m2, (as_val*)&k23, (as_val*)&v23);
+
+	as_hashmap map;
+	as_hashmap_init(&map, 2);
+	as_string k1;
+	as_string_init(&k1, "key1", false);
+	as_hashmap_set(&map, (as_val*)&k1, (as_val*)&m1);
+	as_string k2;
+	as_string_init(&k2, "key2", false);
+	as_hashmap_set(&map, (as_val*)&k2, (as_val*)&m2);
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_map(&rec, BIN_NAME, (as_map*)&map);
+
+	status = aerospike_key_put(as, &err, NULL, &rkey, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_arraylist* keys_in = as_arraylist_new(2, 2);
+	assert_not_null(keys_in);
+	as_arraylist_append_str(keys_in, "key21");
+	as_arraylist_append_str(keys_in, "key23");
+
+	as_cdt_ctx ctx;
+	as_cdt_ctx_inita(&ctx, 2);
+	as_string_init(&k2, "key2", false);
+	as_cdt_ctx_add_map_key(&ctx, (as_val*)&k2);
+	as_cdt_ctx_add_map_keys_in(&ctx, (as_val*)keys_in);
+
+	as_arraylist* query_keys = as_arraylist_new(2, 2);
+	assert_not_null(query_keys);
+	as_arraylist_append_str(query_keys, "key21");
+	as_arraylist_append_str(query_keys, "key23");
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	assert_true(as_operations_map_get_by_key_list(
+			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_KEY_VALUE));
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+
+	assert_not_null(prec);
+	as_bin* results = prec->bins.entries;
+	as_list* list = &results[0].valuep->list;
+	assert_int_eq(as_list_size(list), 2 * 2);
+	assert_string_eq(as_list_get_str(list, 0 * 2), "key21");
+	assert_int_eq(as_list_get_int64(list, 0 * 2 + 1), 3);
+	assert_string_eq(as_list_get_str(list, 1 * 2), "key23");
+	assert_int_eq(as_list_get_int64(list, 1 * 2 + 1), 7);
+
+	as_record_destroy(prec);
+}
+
 TEST(map_double_nested, "Double Nested Map")
 {
 	as_key rkey;
@@ -3723,6 +3819,7 @@ SUITE(map_basics, "aerospike map basic tests")
 	suite_add(map_remove_relative);
 	suite_add(map_partial);
 	suite_add(map_nested);
+	suite_add(map_nested_map_keys_in);
 	suite_add(map_double_nested);
 	suite_add(map_ctx_create);
 	suite_add(map_simple2);

--- a/src/test/aerospike_map/map_basics.c
+++ b/src/test/aerospike_map/map_basics.c
@@ -2047,6 +2047,91 @@ TEST(map_nested_map_keys_in, "Nested map MAP_KEYS_IN context with get by key lis
 	as_record_destroy(prec);
 }
 
+TEST(map_keys_in_and_filter, "MAP_KEYS_IN with AND expression filter on map get by key list")
+{
+	as_key rkey;
+	as_key_init_int64(&rkey, NAMESPACE, SET, 93);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &rkey);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_hashmap map;
+	as_hashmap_init(&map, 4);
+	as_string ka;
+	as_string_init(&ka, "a", false);
+	as_string kb;
+	as_string_init(&kb, "b", false);
+	as_string kc;
+	as_string_init(&kc, "c", false);
+	as_string kd;
+	as_string_init(&kd, "d", false);
+	as_integer va;
+	as_integer_init(&va, 5);
+	as_integer vb;
+	as_integer_init(&vb, 15);
+	as_integer vc;
+	as_integer_init(&vc, 25);
+	as_integer vd;
+	as_integer_init(&vd, 35);
+	as_hashmap_set(&map, (as_val*)&ka, (as_val*)&va);
+	as_hashmap_set(&map, (as_val*)&kb, (as_val*)&vb);
+	as_hashmap_set(&map, (as_val*)&kc, (as_val*)&vc);
+	as_hashmap_set(&map, (as_val*)&kd, (as_val*)&vd);
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_map(&rec, BIN_NAME, (as_map*)&map);
+
+	status = aerospike_key_put(as, &err, NULL, &rkey, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_arraylist* keys_in = as_arraylist_new(2, 2);
+	assert_not_null(keys_in);
+	as_arraylist_append_str(keys_in, "a");
+	as_arraylist_append_str(keys_in, "c");
+
+	as_exp_build(af,
+		as_exp_cmp_gt(
+			as_exp_loopvar_int(AS_EXP_LOOPVAR_VALUE),
+			as_exp_int(10)));
+	assert_not_null(af);
+
+	as_cdt_ctx ctx;
+	as_cdt_ctx_inita(&ctx, 2);
+	as_cdt_ctx_add_map_keys_in(&ctx, (as_list*)keys_in);
+	as_cdt_ctx_add_and_filter(&ctx, af);
+
+	as_arraylist* query_keys = as_arraylist_new(2, 2);
+	assert_not_null(query_keys);
+	as_arraylist_append_str(query_keys, "a");
+	as_arraylist_append_str(query_keys, "c");
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	assert_true(as_operations_map_get_by_key_list(
+			&ops, BIN_NAME, &ctx, (as_list*)query_keys, AS_MAP_RETURN_UNORDERED_MAP));
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	as_exp_destroy(af);
+	as_cdt_ctx_destroy(&ctx);
+
+	assert_not_null(prec);
+	as_map* result = &prec->bins.entries[0].valuep->map;
+	assert_int_eq(as_map_size(result), 1);
+	as_string klookup;
+	as_string_init(&klookup, "c", false);
+	as_integer* iv = (as_integer*)as_map_get(result, (as_val*)&klookup);
+	assert_not_null(iv);
+	assert_int_eq(iv->value, 25);
+
+	as_record_destroy(prec);
+}
+
 TEST(map_double_nested, "Double Nested Map")
 {
 	as_key rkey;
@@ -3830,6 +3915,7 @@ SUITE(map_basics, "aerospike map basic tests")
 	suite_add(map_partial);
 	suite_add(map_nested);
 	suite_add(map_nested_map_keys_in);
+	suite_add(map_keys_in_and_filter);
 	suite_add(map_double_nested);
 	suite_add(map_ctx_create);
 	suite_add(map_simple2);

--- a/src/test/exp_operate.c
+++ b/src/test/exp_operate.c
@@ -16,6 +16,7 @@
  */
 #include <aerospike/aerospike.h>
 #include <aerospike/aerospike_key.h>
+#include <aerospike/as_arraylist.h>
 #include <aerospike/as_exp.h>
 #include <aerospike/as_exp_operations.h>
 #include "test.h"
@@ -938,6 +939,120 @@ TEST(exp_select, "exp select and apply")
 	rec = NULL;
 }
 
+TEST(exp_in_list, "as_exp_in_list string and int membership")
+{
+	as_error err;
+	as_status rc;
+	as_key rkey;
+	as_key_init_int64(&rkey, NAMESPACE, SET, 701);
+
+	/* Start from a clean record for this test key. */
+	rc = aerospike_key_remove(as, &err, NULL, &rkey);
+	assert_true(rc == AEROSPIKE_OK || rc == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	/*------------------------------------------------------------------
+	 * Fixture: bins used by the expressions below.
+	 *   "color" -> "blue"
+	 *   "qty"   -> 5
+	 *----------------------------------------------------------------*/
+	as_record rec;
+	as_record_inita(&rec, 2);
+	as_record_set_str(&rec, "color", "blue");
+	as_record_set_int64(&rec, "qty", 5);
+	rc = aerospike_key_put(as, &err, NULL, &rkey, &rec);
+	assert_int_eq(rc, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_record* oprec = NULL;
+	as_bin* results;
+
+	/*------------------------------------------------------------------
+	 * Case 1: "blue" in ["red", "blue", "green"]  ->  true
+	 *----------------------------------------------------------------*/
+	{
+		as_arraylist* colors = as_arraylist_new(3, 3);
+		assert_not_null(colors);
+		as_arraylist_append_str(colors, "red");
+		as_arraylist_append_str(colors, "blue");
+		as_arraylist_append_str(colors, "green");
+
+		as_exp_build(expr_blue,
+			as_exp_in_list(as_exp_bin_str("color"), colors));
+		assert_not_null(expr_blue);
+		as_arraylist_destroy(colors);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr_blue, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_BOOLEAN);
+		assert_true(as_bin_get_value(&results[0])->boolean.value);
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr_blue);
+	}
+
+	/*------------------------------------------------------------------
+	 * Case 2: "yellow" in ["red", "blue", "green"]  ->  false
+	 * (LHS is a literal; RHS is the same color list as case 1.)
+	 *----------------------------------------------------------------*/
+	{
+		as_arraylist* colors = as_arraylist_new(3, 3);
+		assert_not_null(colors);
+		as_arraylist_append_str(colors, "red");
+		as_arraylist_append_str(colors, "blue");
+		as_arraylist_append_str(colors, "green");
+
+		as_exp_build(expr_yellow,
+			as_exp_in_list(as_exp_str("yellow"), colors));
+		assert_not_null(expr_yellow);
+		as_arraylist_destroy(colors);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr_yellow, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_BOOLEAN);
+		assert_false(as_bin_get_value(&results[0])->boolean.value);
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr_yellow);
+	}
+
+	/*------------------------------------------------------------------
+	 * Case 3: 5 in [1, 5, 10]  ->  true
+	 *----------------------------------------------------------------*/
+	{
+		as_arraylist* nums = as_arraylist_new(3, 3);
+		assert_not_null(nums);
+		as_arraylist_append_int64(nums, 1);
+		as_arraylist_append_int64(nums, 5);
+		as_arraylist_append_int64(nums, 10);
+
+		as_exp_build(expr_five,
+			as_exp_in_list(as_exp_bin_int("qty"), nums));
+		assert_not_null(expr_five);
+		as_arraylist_destroy(nums);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr_five, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_BOOLEAN);
+		assert_true(as_bin_get_value(&results[0])->boolean.value);
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr_five);
+	}
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -958,6 +1073,7 @@ SUITE(exp_operate, "filter expression tests")
 	suite_add(exp_returns_string);
 	suite_add(exp_returns_blob);
 	suite_add(exp_returns_bool);
+	suite_add(exp_in_list);
 	suite_add(exp_returns_hll);
 	suite_add(exp_merge);
 	suite_add(exp_base64);

--- a/src/test/exp_operate.c
+++ b/src/test/exp_operate.c
@@ -21,6 +21,7 @@
 #include <aerospike/as_exp_operations.h>
 #include "test.h"
 #include "util/log_helper.h"
+#include <string.h>
 
 /******************************************************************************
  * GLOBAL VARS
@@ -1053,6 +1054,198 @@ TEST(exp_in_list, "as_exp_in_list string and int membership")
 	}
 }
 
+TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
+{
+	as_error err;
+	as_status rc;
+	as_key rkey;
+	as_key_init_int64(&rkey, NAMESPACE, SET, 702);
+
+	/*------------------------------------------------------------------
+	 * Setup: remove any prior record for this key.
+	 *----------------------------------------------------------------*/
+	rc = aerospike_key_remove(as, &err, NULL, &rkey);
+	assert_true(rc == AEROSPIKE_OK || rc == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	/*------------------------------------------------------------------
+	 * Fixture: ordered map bin "m" -> { "a": 1, "b": 2 }
+	 *----------------------------------------------------------------*/
+	as_orderedmap mfix;
+	as_orderedmap_init(&mfix, 4);
+	as_orderedmap_set(&mfix, (as_val*)as_string_new((char*)"a", false),
+			(as_val*)as_integer_new(1));
+	as_orderedmap_set(&mfix, (as_val*)as_string_new((char*)"b", false),
+			(as_val*)as_integer_new(2));
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_map(&rec, "m", (as_map*)&mfix);
+	rc = aerospike_key_put(as, &err, NULL, &rkey, &rec);
+	assert_int_eq(rc, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_record* oprec = NULL;
+	as_bin* results;
+
+	/*------------------------------------------------------------------
+	 * Case 1: map_keys(as_exp_bin_map("m")) -> list containing "a", "b"
+	 *----------------------------------------------------------------*/
+	{
+		as_exp_build(expr, as_exp_map_keys(as_exp_bin_map("m")));
+		assert_not_null(expr);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_LIST);
+		as_list* kl = (as_list*)as_bin_get_value(&results[0]);
+		assert_int_eq(as_list_size(kl), 2);
+		bool has_a = false;
+		bool has_b = false;
+		for (uint32_t i = 0; i < (uint32_t)as_list_size(kl); i++) {
+			as_string* s = as_list_get_string(kl, i);
+			assert_not_null(s);
+			const char* p = as_string_get(s);
+			if (strcmp(p, "a") == 0) {
+				has_a = true;
+			}
+			if (strcmp(p, "b") == 0) {
+				has_b = true;
+			}
+		}
+		assert_true(has_a);
+		assert_true(has_b);
+
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr);
+	}
+
+	/*------------------------------------------------------------------
+	 * Case 2: map_values(as_exp_bin_map("m")) -> list containing 1, 2
+	 *----------------------------------------------------------------*/
+	{
+		as_exp_build(expr, as_exp_map_values(as_exp_bin_map("m")));
+		assert_not_null(expr);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_LIST);
+		as_list* vl = (as_list*)as_bin_get_value(&results[0]);
+		assert_int_eq(as_list_size(vl), 2);
+		bool has_one = false;
+		bool has_two = false;
+		for (uint32_t i = 0; i < (uint32_t)as_list_size(vl); i++) {
+			int64_t v = as_list_get_int64(vl, i);
+			if (v == 1) {
+				has_one = true;
+			}
+			if (v == 2) {
+				has_two = true;
+			}
+		}
+		assert_true(has_one);
+		assert_true(has_two);
+
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr);
+	}
+
+	/*------------------------------------------------------------------
+	 * Case 3: literal map — map_keys / map_values via as_exp_val
+	 *----------------------------------------------------------------*/
+	{
+		as_orderedmap* lit = as_orderedmap_new(2);
+		assert_not_null(lit);
+		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"a", false),
+				(as_val*)as_integer_new(1));
+		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"b", false),
+				(as_val*)as_integer_new(2));
+
+		as_exp_build(expr_k, as_exp_map_keys(as_exp_val((as_val*)lit)));
+		assert_not_null(expr_k);
+		as_orderedmap_destroy(lit);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr_k, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_LIST);
+		as_list* kl = (as_list*)as_bin_get_value(&results[0]);
+		assert_int_eq(as_list_size(kl), 2);
+		bool has_a = false;
+		bool has_b = false;
+		for (uint32_t i = 0; i < (uint32_t)as_list_size(kl); i++) {
+			as_string* s = as_list_get_string(kl, i);
+			assert_not_null(s);
+			const char* p = as_string_get(s);
+			if (strcmp(p, "a") == 0) {
+				has_a = true;
+			}
+			if (strcmp(p, "b") == 0) {
+				has_b = true;
+			}
+		}
+		assert_true(has_a);
+		assert_true(has_b);
+
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr_k);
+	}
+
+	{
+		as_orderedmap* lit = as_orderedmap_new(2);
+		assert_not_null(lit);
+		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"a", false),
+				(as_val*)as_integer_new(1));
+		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"b", false),
+				(as_val*)as_integer_new(2));
+
+		as_exp_build(expr_v, as_exp_map_values(as_exp_val((as_val*)lit)));
+		assert_not_null(expr_v);
+		as_orderedmap_destroy(lit);
+
+		as_operations_inita(&ops, 1);
+		as_operations_exp_read(&ops, ExpVar, expr_v, AS_EXP_READ_DEFAULT);
+		oprec = NULL;
+		rc = aerospike_key_operate(as, &err, NULL, &rkey, &ops, &oprec);
+		assert_int_eq(rc, AEROSPIKE_OK);
+		results = oprec->bins.entries;
+		assert_int_eq(as_bin_get_type(&results[0]), AS_LIST);
+		as_list* vl = (as_list*)as_bin_get_value(&results[0]);
+		assert_int_eq(as_list_size(vl), 2);
+		bool has_one = false;
+		bool has_two = false;
+		for (uint32_t i = 0; i < (uint32_t)as_list_size(vl); i++) {
+			int64_t v = as_list_get_int64(vl, i);
+			if (v == 1) {
+				has_one = true;
+			}
+			if (v == 2) {
+				has_two = true;
+			}
+		}
+		assert_true(has_one);
+		assert_true(has_two);
+
+		as_record_destroy(oprec);
+		as_operations_destroy(&ops);
+		as_exp_destroy(expr_v);
+	}
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -1074,6 +1267,7 @@ SUITE(exp_operate, "filter expression tests")
 	suite_add(exp_returns_blob);
 	suite_add(exp_returns_bool);
 	suite_add(exp_in_list);
+	suite_add(exp_map_keys_values);
 	suite_add(exp_returns_hll);
 	suite_add(exp_merge);
 	suite_add(exp_base64);


### PR DESCRIPTION
This PR is intended to implement the features set out by Mirza in https://aerospike.atlassian.net/wiki/spaces/CLIENTS/pages/5024153605/Path+Expressions+Enhancements+P1 .

The only part not explicitly implemented is part 6, which aims to fix how to detect AS_CDT_EXP with or without the AS_CDT_AND flag set.  The code in this PR works around this by just ANDing against ~AS_CDT_AND instead, which achieves the same result.  Moreover, the Path Expressions Enhancements document is, I think, misleading, since it appears to need 0xFF as the mask instead of 0x0F.  ANDing with ~AS_CDT_AND seems more correct for the time being.