### PR TITLE
CLIENT-4314: support set indices 

### DIFF
--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -135,6 +135,11 @@ struct as_exp;
 
 /**
  * Create secondary index given collection type, data type and context.
+ * 
+ * When creating a set index, neither bin name nor data type are supported.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * If any of these are provided when making a set index, you'll receive back
+ * an error from the server indicating the issue.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
@@ -176,6 +181,11 @@ aerospike_index_create_ctx(
 /**
  * Create secondary index on an expression.
  *
+ * When creating a set index, neither bin name nor data type are supported.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * If any of these are provided when making a set index, you'll receive back
+ * an error from the server indicating the issue.
+ *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
  *
@@ -215,6 +225,11 @@ aerospike_index_create_exp(
 /**
  * Create secondary index given collection type and data type.
  *
+ * When creating a set index, neither bin name nor data type are supported.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * If any of these are provided when making a set index, you'll receive back
+ * an error from the server indicating the issue.
+ *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
  *
@@ -224,7 +239,7 @@ aerospike_index_create_exp(
  *     "idx_test_demo_bin1", AS_INDEX_TYPE_DEFAULT, AS_INDEX_NUMERIC) == AEROSPIKE_OK) {
  *     aerospike_index_create_wait(&err, &task, 0);
  * }
-* @endcode
+ * @endcode
  *
  * @param as			The aerospike instance to use for this operation.
  * @param err			The as_error to be populated if an error occurs.
@@ -255,6 +270,9 @@ aerospike_index_create_complex(
 
 /**
  * Create secondary index given data type.
+ *
+ * This function cannot be used to create a set index.  To create a set index,
+ * please consider using @see aerospike_index_create_complex instead.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -70,7 +70,8 @@ typedef enum as_index_type_s {
 	AS_INDEX_TYPE_DEFAULT,
 	AS_INDEX_TYPE_LIST,
 	AS_INDEX_TYPE_MAPKEYS,
-	AS_INDEX_TYPE_MAPVALUES
+	AS_INDEX_TYPE_MAPVALUES,
+	AS_INDEX_TYPE_SET
 } as_index_type;
 
 /*
@@ -181,7 +182,7 @@ aerospike_index_create_ctx(
  * as_exp_build(exp, as_exp_add(as_exp_bin_int("a"), as_exp_bin_int("b")));
  *
  * as_index_task task;
- * if (aerospike_index_create_ctx(&as, &err, &task, NULL, "test", "demo",
+ * if (aerospike_index_create_exp(&as, &err, &task, NULL, "test", "demo",
  *     "idx_test_demo_bin1", AS_INDEX_TYPE_DEFAULT, AS_INDEX_NUMERIC, exp) == AEROSPIKE_OK) {
  *     aerospike_index_create_wait(&err, &task, 0);
  * }

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -272,7 +272,7 @@ aerospike_index_create_complex(
  * Create secondary index given data type.
  *
  * This function cannot be used to create a set index.  To create a set index,
- * please consider using @see aerospike_index_create_complex instead.
+ * please consider using `aerospike_index_create_complex()` instead.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
@@ -297,6 +297,7 @@ aerospike_index_create_complex(
  *
  * @return AEROSPIKE_OK if successful. Return AEROSPIKE_ERR_INDEX_FOUND if index exists. Otherwise an error.
  *
+ * @see aerospike_index_create_complex
  * @ingroup index_operations
  */
 static inline as_status

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -82,8 +82,19 @@ typedef enum as_index_datatype_s {
 	AS_INDEX_NUMERIC,
 	AS_INDEX_GEO2DSPHERE,
 	AS_INDEX_BLOB, // Requires server version 7.0+.
-	AS_INDEX_NONE  // Requires server version 8.1.2+.
+	AS_INDEX_INTEGER,
 } as_index_datatype;
+
+/*
+ * When creating set indices, the specific data type doesn't matter.
+ * This definition provides a convenient way of expressing that you
+ * don't care about the data type.
+ *
+ * Should match the default case label for the dtype parameter
+ * in aerospike_create_index_private().
+ */
+#define AS_INDEX_DEFAULT  AS_INDEX_STRING
+
 
 /**
  * Index Task
@@ -137,7 +148,7 @@ struct as_exp;
  * Create secondary index given collection type, data type and context.
  * 
  * When creating a set index, neither bin name nor data type are supported.
- * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
  * If any of these are provided when making a set index, you'll receive back
  * an error from the server indicating the issue.
  *
@@ -182,7 +193,7 @@ aerospike_index_create_ctx(
  * Create secondary index on an expression.
  *
  * When creating a set index, neither bin name nor data type are supported.
- * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
  * If any of these are provided when making a set index, you'll receive back
  * an error from the server indicating the issue.
  *
@@ -226,7 +237,7 @@ aerospike_index_create_exp(
  * Create secondary index given collection type and data type.
  *
  * When creating a set index, neither bin name nor data type are supported.
- * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_NONE.
+ * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
  * If any of these are provided when making a set index, you'll receive back
  * an error from the server indicating the issue.
  *

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -81,7 +81,8 @@ typedef enum as_index_datatype_s {
 	AS_INDEX_STRING,
 	AS_INDEX_NUMERIC,
 	AS_INDEX_GEO2DSPHERE,
-	AS_INDEX_BLOB  // Requires server version 7.0+.
+	AS_INDEX_BLOB, // Requires server version 7.0+.
+	AS_INDEX_NONE  // Requires server version 8.1.2+.
 } as_index_datatype;
 
 /**

--- a/src/include/aerospike/aerospike_index.h
+++ b/src/include/aerospike/aerospike_index.h
@@ -149,8 +149,6 @@ struct as_exp;
  * 
  * When creating a set index, neither bin name nor data type are supported.
  * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
- * If any of these are provided when making a set index, you'll receive back
- * an error from the server indicating the issue.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
@@ -194,8 +192,6 @@ aerospike_index_create_ctx(
  *
  * When creating a set index, neither bin name nor data type are supported.
  * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
- * If any of these are provided when making a set index, you'll receive back
- * an error from the server indicating the issue.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.
@@ -238,8 +234,6 @@ aerospike_index_create_exp(
  *
  * When creating a set index, neither bin name nor data type are supported.
  * Set the bin name to NULL and the `dtype` parameter to AS_INDEX_DEFAULT.
- * If any of these are provided when making a set index, you'll receive back
- * an error from the server indicating the issue.
  *
  * This asynchronous server call will return before the command is complete.
  * The user can optionally wait for command completion by using a task instance.

--- a/src/include/aerospike/as_version.h
+++ b/src/include/aerospike/as_version.h
@@ -72,6 +72,7 @@ as_version_compare(const as_version* ver1, const as_version* ver2);
 AS_EXTERN extern as_version as_server_version_8_1;
 AS_EXTERN extern as_version as_server_version_8_1_1;
 AS_EXTERN extern as_version as_server_version_8_1_2;
+AS_EXTERN extern as_version as_server_version_8_1_3;
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/src/include/aerospike/as_version.h
+++ b/src/include/aerospike/as_version.h
@@ -71,7 +71,6 @@ as_version_compare(const as_version* ver1, const as_version* ver2);
 
 AS_EXTERN extern as_version as_server_version_8_1;
 AS_EXTERN extern as_version as_server_version_8_1_1;
-AS_EXTERN extern as_version as_server_version_8_1_2;
 AS_EXTERN extern as_version as_server_version_8_1_3;
 
 #ifdef __cplusplus

--- a/src/include/aerospike/as_version.h
+++ b/src/include/aerospike/as_version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/src/include/aerospike/as_version.h
+++ b/src/include/aerospike/as_version.h
@@ -71,6 +71,7 @@ as_version_compare(const as_version* ver1, const as_version* ver2);
 
 AS_EXTERN extern as_version as_server_version_8_1;
 AS_EXTERN extern as_version as_server_version_8_1_1;
+AS_EXTERN extern as_version as_server_version_8_1_2;
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -51,6 +51,12 @@ aerospike_index_create_private(
 		policy = &config->policies.info;
 	}
 
+	as_node* node = as_node_get_random(as->cluster);
+
+	if (!node) {
+		return as_error_update(err, AEROSPIKE_ERR_CLIENT, "as_node_get_random() failed");
+	}
+
 	const char* dtype_string;
 	switch (dtype) {
 		case AS_INDEX_NUMERIC:
@@ -65,6 +71,15 @@ aerospike_index_create_private(
 		default:
 		case AS_INDEX_STRING:
 			dtype_string = "STRING";
+			break;
+		// For AS_INDEX_TYPE_SET indices
+		case AS_INDEX_NONE:
+			if (as_version_compare(&node->version, &as_server_version_8_1_2) >= 0) {
+				dtype_string = NULL;
+			}
+			else {
+				dtype_string = "STRING";
+			}
 			break;
 	}
 
@@ -93,12 +108,6 @@ aerospike_index_create_private(
 		}
 	}
 
-	as_node* node = as_node_get_random(as->cluster);
-
-	if (!node) {
-		return as_error_update(err, AEROSPIKE_ERR_CLIENT, "as_node_get_random() failed");
-	}
-
 	as_string_builder sb;
 	as_string_builder_inita(&sb, 16384, false);
 	as_string_builder_append(&sb, "sindex-create:");
@@ -124,8 +133,10 @@ aerospike_index_create_private(
 		as_string_builder_append(&sb, ";indextype=");
 		as_string_builder_append(&sb, itype_string);
 
-		as_string_builder_append(&sb, ";type=");
-		as_string_builder_append(&sb, dtype_string);
+		if (dtype_string) {
+			as_string_builder_append(&sb, ";type=");
+			as_string_builder_append(&sb, dtype_string);
+		}
 	}
 	else {
 		if (ctx) {
@@ -155,7 +166,20 @@ aerospike_index_create_private(
 		as_string_builder_append(&sb, ";indextype=");
 		as_string_builder_append(&sb, itype_string);
 
-		if (as_version_compare(&node->version, &as_server_version_8_1) >= 0) {
+		if ((as_version_compare(&node->version, &as_server_version_8_1_2) >= 0) && (itype == AS_INDEX_TYPE_SET)) {
+			// SET doesn't support bin or data type fields; so, only provide them
+			// if they're specified.  This gives the user a chance to respond to
+			// server-generated error messages.
+			if (bin_name) {
+				as_string_builder_append(&sb, ";bin=");
+				as_string_builder_append(&sb, bin_name);
+			}
+			if (dtype_string) {
+				as_string_builder_append(&sb, ";type=");
+				as_string_builder_append(&sb, dtype_string);
+			}
+		}
+		else if (as_version_compare(&node->version, &as_server_version_8_1) >= 0) {
 			as_string_builder_append(&sb, ";bin=");
 			as_string_builder_append(&sb, bin_name);
 			as_string_builder_append(&sb, ";type=");

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -57,12 +57,6 @@ aerospike_index_create_private(
 		return as_error_update(err, AEROSPIKE_ERR_CLIENT, "as_node_get_random() failed");
 	}
 
-	// Cache results of this specific version check because
-	// we check it several times, and should save some time.
-	// Other version checks happen only once, so won't gain
-	// benefit for caching.
-	bool is_server_8_1_2 = as_version_compare(&node->version, &as_server_version_8_1_2) >= 0;
-
 	const char* dtype_string;
 	switch (dtype) {
 		case AS_INDEX_NUMERIC:
@@ -77,16 +71,6 @@ aerospike_index_create_private(
 		default:
 		case AS_INDEX_STRING:
 			dtype_string = "STRING";
-			break;
-		// For AS_INDEX_TYPE_SET indices
-		case AS_INDEX_NONE:
-			if (is_server_8_1_2) {
-				dtype_string = NULL;
-			}
-			else {
-				// Preserve client 7.3.0 and earlier behavior
-				dtype_string = "STRING";
-			}
 			break;
 	}
 
@@ -130,85 +114,69 @@ aerospike_index_create_private(
 	as_string_builder_append(&sb, ";indexname=");
 	as_string_builder_append(&sb, index_name);
 
-	if (exp) {
-		char* b64 = as_exp_to_base64(exp);
-
-		as_string_builder_append(&sb, ";exp=");
-		as_string_builder_append(&sb, b64);
-		cf_free(b64);
-
-		as_string_builder_append(&sb, ";indextype=");
-		as_string_builder_append(&sb, itype_string);
-
-		if (dtype_string) {
-			as_string_builder_append(&sb, ";type=");
-			as_string_builder_append(&sb, dtype_string);
-		}
+	if (itype == AS_INDEX_TYPE_SET) {
+		as_string_builder_append(&sb, ";indextype=SET");
 	}
 	else {
-		if (ctx) {
-			as_packer pk = {.buffer = NULL, .capacity = UINT32_MAX};
-
-			if (as_cdt_ctx_pack(ctx, &pk) == 0) {
-				as_node_release(node);
-				return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Failed to pack ctx");
+		if (as_version_compare(&node->version, &as_server_version_8_1_3) >= 0) {
+			if (dtype == AS_INDEX_NUMERIC) {
+				dtype = AS_INDEX_INTEGER;
+				dtype_string = "INTEGER";
 			}
-
-			char* context = cf_malloc(pk.offset);
-			uint32_t b64_sz = cf_b64_encoded_len(pk.offset);
-
-			char* b64 = cf_malloc(b64_sz + 1);
-			pk.buffer = (uint8_t*)context;
-			pk.offset = 0;
-			as_cdt_ctx_pack(ctx, &pk);
-			cf_b64_encode(pk.buffer, pk.offset, b64);
-			b64[b64_sz] = 0;
-			cf_free(context);
-
-			as_string_builder_append(&sb, ";context=");
-			as_string_builder_append(&sb, b64);
-			cf_free(b64);
+		}
+		else {
+			if (dtype == AS_INDEX_INTEGER) {
+				dtype = AS_INDEX_NUMERIC;
+				dtype_string = "NUMERIC";
+			}
 		}
 
-		as_string_builder_append(&sb, ";indextype=");
-		as_string_builder_append(&sb, itype_string);
+		if (exp) {
+			char* b64 = as_exp_to_base64(exp);
 
-		if (is_server_8_1_2 && itype == AS_INDEX_TYPE_SET) {
-			// SET doesn't support bin or data type fields; so, only provide them
-			// if they're specified.  This gives the user a chance to respond to
-			// server-generated error messages.
-			if (bin_name) {
-				as_string_builder_append(&sb, ";bin=");
-				as_string_builder_append(&sb, bin_name);
+			as_string_builder_append(&sb, ";exp=");
+			as_string_builder_append(&sb, b64);
+			cf_free(b64);
+
+			// Matches C# logic per Shannon's recommendation
+			if (itype != AS_INDEX_TYPE_DEFAULT) {
+				as_string_builder_append(&sb, ";indextype=");
+				as_string_builder_append(&sb, itype_string);
 			}
+
 			if (dtype_string) {
 				as_string_builder_append(&sb, ";type=");
 				as_string_builder_append(&sb, dtype_string);
 			}
 		}
 		else {
-			// if itype != AS_INDEX_TYPE_SET
-			// OR if we're addressing server 8.1.1 or earlier
-			// then execute this section of code, exactly as
-			// we would from version 7.3.0 of this client.
+			if (ctx) {
+				as_packer pk = {.buffer = NULL, .capacity = UINT32_MAX};
 
-			if (bin_name == NULL) {
-				// Avoid a segmentation fault by returning an error
-				if (is_server_8_1_2) {
-					// itype must not be AS_INDEX_TYPE_SET
-					return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Bin name can only be NULL when creating set indexes");
+				if (as_cdt_ctx_pack(ctx, &pk) == 0) {
+					as_node_release(node);
+					return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Failed to pack ctx");
 				}
-				else {
-					// Earlier version of server that doesn't support set indices;
-					// save the round trip overhead.
-					return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Bin name cannot be NULL");
-				}
+
+				char* context = cf_malloc(pk.offset);
+				uint32_t b64_sz = cf_b64_encoded_len(pk.offset);
+
+				char* b64 = cf_malloc(b64_sz + 1);
+				pk.buffer = (uint8_t*)context;
+				pk.offset = 0;
+				as_cdt_ctx_pack(ctx, &pk);
+				cf_b64_encode(pk.buffer, pk.offset, b64);
+				b64[b64_sz] = 0;
+				cf_free(context);
+
+				as_string_builder_append(&sb, ";context=");
+				as_string_builder_append(&sb, b64);
+				cf_free(b64);
 			}
 
-			if (dtype == AS_INDEX_NONE) {
-				// Simply log a warning here because, per 7.3.0 logic,
-				// dtype_string will contain "STRING", since it is the default case.
-				as_log_warn("Attempt to create non-set index with a data type set to AS_INDEX_NONE");
+			if (itype != AS_INDEX_TYPE_DEFAULT) {
+				as_string_builder_append(&sb, ";indextype=");
+				as_string_builder_append(&sb, itype_string);
 			}
 
 			if (as_version_compare(&node->version, &as_server_version_8_1) >= 0) {

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -186,17 +186,43 @@ aerospike_index_create_private(
 				as_string_builder_append(&sb, dtype_string);
 			}
 		}
-		else if (as_version_compare(&node->version, &as_server_version_8_1) >= 0) {
-			as_string_builder_append(&sb, ";bin=");
-			as_string_builder_append(&sb, bin_name);
-			as_string_builder_append(&sb, ";type=");
-			as_string_builder_append(&sb, dtype_string);
-		}
 		else {
-			as_string_builder_append(&sb, ";indexdata=");
-			as_string_builder_append(&sb, bin_name);
-			as_string_builder_append_char(&sb, ',');
-			as_string_builder_append(&sb, dtype_string);
+			// if itype != AS_INDEX_TYPE_SET
+			// OR if we're addressing server 8.1.1 or earlier
+			// then execute this section of code, exactly as
+			// we would from version 7.3.0 of this client.
+
+			if (bin_name == NULL) {
+				// Avoid a segmentation fault by returning an error
+				if (is_server_8_1_2) {
+					// itype must not be AS_INDEX_TYPE_SET
+					return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Bin name can only be NULL when creating set indexes");
+				}
+				else {
+					// Earlier version of server that doesn't support set indices;
+					// save the round trip overhead.
+					return as_error_update(err, AEROSPIKE_ERR_CLIENT, "Bin name cannot be NULL");
+				}
+			}
+
+			if (dtype == AS_INDEX_NONE) {
+				// Simply log a warning here because, per 7.3.0 logic,
+				// dtype_string will contain "STRING", since it is the default case.
+				as_log_warn("Attempt to create non-set index with a data type set to AS_INDEX_NONE");
+			}
+
+			if (as_version_compare(&node->version, &as_server_version_8_1) >= 0) {
+				as_string_builder_append(&sb, ";bin=");
+				as_string_builder_append(&sb, bin_name);
+				as_string_builder_append(&sb, ";type=");
+				as_string_builder_append(&sb, dtype_string);
+			}
+			else {
+				as_string_builder_append(&sb, ";indexdata=");
+				as_string_builder_append(&sb, bin_name);
+				as_string_builder_append_char(&sb, ',');
+				as_string_builder_append(&sb, dtype_string);
+			}
 		}
 	}
 

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -19,7 +19,6 @@
 #include <aerospike/as_cdt_internal.h>
 #include <aerospike/as_cluster.h>
 #include <aerospike/as_exp.h>
-// #include <aerospike/as_log.h>
 #include <aerospike/as_log_macros.h>
 #include <aerospike/as_sleep.h>
 #include <aerospike/as_string_builder.h>

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -57,6 +57,12 @@ aerospike_index_create_private(
 		return as_error_update(err, AEROSPIKE_ERR_CLIENT, "as_node_get_random() failed");
 	}
 
+	// Cache results of this specific version check because
+	// we check it several times, and should save some time.
+	// Other version checks happen only once, so won't gain
+	// benefit for caching.
+	bool is_server_8_1_2 = as_version_compare(&node->version, &as_server_version_8_1_2) >= 0;
+
 	const char* dtype_string;
 	switch (dtype) {
 		case AS_INDEX_NUMERIC:
@@ -74,7 +80,7 @@ aerospike_index_create_private(
 			break;
 		// For AS_INDEX_TYPE_SET indices
 		case AS_INDEX_NONE:
-			if (as_version_compare(&node->version, &as_server_version_8_1_2) >= 0) {
+			if (is_server_8_1_2) {
 				dtype_string = NULL;
 			}
 			else {
@@ -167,7 +173,7 @@ aerospike_index_create_private(
 		as_string_builder_append(&sb, ";indextype=");
 		as_string_builder_append(&sb, itype_string);
 
-		if ((as_version_compare(&node->version, &as_server_version_8_1_2) >= 0) && (itype == AS_INDEX_TYPE_SET)) {
+		if (is_server_8_1_2 && itype == AS_INDEX_TYPE_SET) {
 			// SET doesn't support bin or data type fields; so, only provide them
 			// if they're specified.  This gives the user a chance to respond to
 			// server-generated error messages.

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -87,6 +87,10 @@ aerospike_index_create_private(
 			itype_string = "MAPVALUES";
 			break;
 		}
+		case AS_INDEX_TYPE_SET: {
+			itype_string = "SET";
+			break;
+		}
 	}
 
 	as_node* node = as_node_get_random(as->cluster);

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -19,7 +19,8 @@
 #include <aerospike/as_cdt_internal.h>
 #include <aerospike/as_cluster.h>
 #include <aerospike/as_exp.h>
-#include <aerospike/as_log.h>
+// #include <aerospike/as_log.h>
+#include <aerospike/as_log_macros.h>
 #include <aerospike/as_sleep.h>
 #include <aerospike/as_string_builder.h>
 #include <citrusleaf/alloc.h>

--- a/src/main/aerospike/aerospike_index.c
+++ b/src/main/aerospike/aerospike_index.c
@@ -78,6 +78,7 @@ aerospike_index_create_private(
 				dtype_string = NULL;
 			}
 			else {
+				// Preserve client 7.3.0 and earlier behavior
 				dtype_string = "STRING";
 			}
 			break;

--- a/src/main/aerospike/as_version.c
+++ b/src/main/aerospike/as_version.c
@@ -23,7 +23,6 @@
 
 as_version as_server_version_8_1 = {8, 1, 0, 0};
 as_version as_server_version_8_1_1 = {8, 1, 1, 0};
-as_version as_server_version_8_1_2 = {8, 1, 2, 0};
 as_version as_server_version_8_1_3 = {8, 1, 3, 0};
 
 //---------------------------------

--- a/src/main/aerospike/as_version.c
+++ b/src/main/aerospike/as_version.c
@@ -24,6 +24,7 @@
 as_version as_server_version_8_1 = {8, 1, 0, 0};
 as_version as_server_version_8_1_1 = {8, 1, 1, 0};
 as_version as_server_version_8_1_2 = {8, 1, 2, 0};
+as_version as_server_version_8_1_3 = {8, 1, 3, 0};
 
 //---------------------------------
 // Functions

--- a/src/main/aerospike/as_version.c
+++ b/src/main/aerospike/as_version.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/src/main/aerospike/as_version.c
+++ b/src/main/aerospike/as_version.c
@@ -23,6 +23,7 @@
 
 as_version as_server_version_8_1 = {8, 1, 0, 0};
 as_version as_server_version_8_1_1 = {8, 1, 1, 0};
+as_version as_server_version_8_1_2 = {8, 1, 2, 0};
 
 //---------------------------------
 // Functions

--- a/src/test/aerospike_index/index_basics.c
+++ b/src/test/aerospike_index/index_basics.c
@@ -91,21 +91,21 @@ TEST(index_basics_drop , "Drop index")
 
 	// DEFAULT type index
 	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_new_bin");
-	if ( err.code != AEROSPIKE_OK ) {
+	if (err.code != AEROSPIKE_OK) {
 		info("error(%d): %s", err.code, err.message);
 	}
 	assert_int_eq( err.code, AEROSPIKE_OK );
 
 	// LIST type index
 	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_listbin");
-	if ( err.code != AEROSPIKE_OK ) {
+	if (err.code != AEROSPIKE_OK) {
 		info("error(%d): %s", err.code, err.message);
 	}
 	assert_int_eq( err.code, AEROSPIKE_OK );
 
 	// SET type index
 	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_set");
-	if ( err.code != AEROSPIKE_OK ) {
+	if (err.code != AEROSPIKE_OK) {
 		info("error(%d): %s", err.code, err.message);
 	}
 	assert_int_eq( err.code, AEROSPIKE_OK );

--- a/src/test/aerospike_index/index_basics.c
+++ b/src/test/aerospike_index/index_basics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/src/test/aerospike_index/index_basics.c
+++ b/src/test/aerospike_index/index_basics.c
@@ -77,7 +77,7 @@ TEST(index_basics_create, "Create index on bin")
 	// SET type index (bin and dtype parameters not supported)
 	status = aerospike_index_create_complex(as, &err, &task, NULL, NAMESPACE,
 			SET, NULL, "idx_test_set", AS_INDEX_TYPE_SET,
-			AS_INDEX_NONE);
+			AS_INDEX_DEFAULT);
 
 	if (! index_process_return_code(status, &err, &task)) {
 		assert_int_eq(status , AEROSPIKE_OK);

--- a/src/test/aerospike_index/index_basics.c
+++ b/src/test/aerospike_index/index_basics.c
@@ -76,7 +76,7 @@ TEST(index_basics_create, "Create index on bin")
 
 	// SET type index (bin and dtype parameters not supported)
 	status = aerospike_index_create_complex(as, &err, &task, NULL, NAMESPACE,
-			SET, NULL, "idx_test_setbin", AS_INDEX_TYPE_SET,
+			SET, NULL, "idx_test_set", AS_INDEX_TYPE_SET,
 			AS_INDEX_NONE);
 
 	if (! index_process_return_code(status, &err, &task)) {
@@ -104,7 +104,7 @@ TEST(index_basics_drop , "Drop index")
 	assert_int_eq( err.code, AEROSPIKE_OK );
 
 	// SET type index
-	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_setbin");
+	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_set");
 	if ( err.code != AEROSPIKE_OK ) {
 		info("error(%d): %s", err.code, err.message);
 	}

--- a/src/test/aerospike_index/index_basics.c
+++ b/src/test/aerospike_index/index_basics.c
@@ -73,6 +73,15 @@ TEST(index_basics_create, "Create index on bin")
 	if (! index_process_return_code(status, &err, &task)) {
 		assert_int_eq(status , AEROSPIKE_OK);
 	}
+
+	// SET type index (bin and dtype parameters not supported)
+	status = aerospike_index_create_complex(as, &err, &task, NULL, NAMESPACE,
+			SET, NULL, "idx_test_setbin", AS_INDEX_TYPE_SET,
+			AS_INDEX_NONE);
+
+	if (! index_process_return_code(status, &err, &task)) {
+		assert_int_eq(status , AEROSPIKE_OK);
+	}
 }
 
 TEST(index_basics_drop , "Drop index")
@@ -89,6 +98,13 @@ TEST(index_basics_drop , "Drop index")
 
 	// LIST type index
 	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_listbin");
+	if ( err.code != AEROSPIKE_OK ) {
+		info("error(%d): %s", err.code, err.message);
+	}
+	assert_int_eq( err.code, AEROSPIKE_OK );
+
+	// SET type index
+	aerospike_index_remove(as, &err, NULL, NAMESPACE, "idx_test_setbin");
 	if ( err.code != AEROSPIKE_OK ) {
 		info("error(%d): %s", err.code, err.message);
 	}


### PR DESCRIPTION
The original ticket specified that the new indices are to use the sindex-admin role because of Aerospike Cloud limitations.  I confirmed with Brian N that the C client already supported sindex-admin roles (via the AS_PRIVILEGE_SINDEX_ADMIN privilege).  This ticket just rounds out the feature to support the SET index type.
