### PR TITLE
[CLIENT-4704] Fix memory leak where adding an operation fails because of the bin name being too long

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,5 @@ jobs:
     - run: sleep 5
     - run: make EVENT_LIB=${{ matrix.EVENT_LIB }} test${{ matrix.valgrind && '-valgrind' || '' }}
     - if: ${{ matrix.valgrind }}
-      run: cat client_test-valgrind
+      run: |
+        grep 'ERROR SUMMARY: 0 errors' client_test-valgrind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       with:
         submodules: recursive
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Setup Aerospike Database
-      uses: reugn/github-action-aerospike@v1
+    - run: docker run -d -p 3000:3000 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:8.1.2.0
+    - run: sleep 5
     - run: ./install_libev
     - run: make EVENT_LIB=libev
     - run: make EVENT_LIB=libev test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,26 +7,27 @@ on:
     branches: [master, stage]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     env:
       LD_LIBRARY_PATH: /usr/local/lib
+    strategy:
+      matrix:
+        EVENT_LIB:
+        - libev
+        - libuv
+        - libevent
+      fail-fast: false
     steps:
     - name: Checkout client
       uses: actions/checkout@v2
       with:
         submodules: recursive
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - run: ./install_${{ matrix.EVENT_LIB }}
+    - run: make EVENT_LIB=${{ matrix.EVENT_LIB }}
+
     - run: docker run -d -p 3000:3000 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:8.1.2.0
     - run: sleep 5
-    - run: ./install_libev
-    - run: make EVENT_LIB=libev
-    - run: make EVENT_LIB=libev test
-    - run: make clean
-    - run: ./install_libuv
-    - run: make EVENT_LIB=libuv
-    - run: make EVENT_LIB=libuv test
-    - run: make clean
-    - run: ./install_libevent
-    - run: make EVENT_LIB=libevent
-    - run: make EVENT_LIB=libevent test
+    - run: make EVENT_LIB=${{ matrix.EVENT_LIB }} test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,12 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - run: ./install_${{ matrix.EVENT_LIB }}
+
+    - if: ${{ matrix.valgrind }}
+      run: |
+        sudo apt update
+        sudo apt install -y valgrind
+
     - run: make EVENT_LIB=${{ matrix.EVENT_LIB }}
 
     - run: docker run -d -p 3000:3000 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:8.1.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,5 @@ jobs:
     - run: docker run -d -p 3000:3000 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:8.1.2.0
     - run: sleep 5
     - run: make EVENT_LIB=${{ matrix.EVENT_LIB }} test${{ matrix.valgrind && '-valgrind' || '' }}
+    - if: ${{ matrix.valgrind }}
+      run: cat client_test-valgrind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
         - libev
         - libuv
         - libevent
+        valgrind:
+        - false
+        - true
       fail-fast: false
     steps:
     - name: Checkout client
@@ -30,4 +33,4 @@ jobs:
 
     - run: docker run -d -p 3000:3000 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:8.1.2.0
     - run: sleep 5
-    - run: make EVENT_LIB=${{ matrix.EVENT_LIB }} test
+    - run: make EVENT_LIB=${{ matrix.EVENT_LIB }} test${{ matrix.valgrind && '-valgrind' || '' }}

--- a/src/include/aerospike/as_operations.h
+++ b/src/include/aerospike/as_operations.h
@@ -265,7 +265,7 @@ typedef struct as_binops_s {
 typedef struct as_operations_s {
 
 	/**
-     * Operations to be performed on the bins of a record.
+	 * Operations to be performed on the bins of a record.
 	 */
 	as_binops binops;
 	

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -138,10 +138,6 @@ as_cdt_add_packed(as_packer* pk, as_operations* ops, const char* name, as_operat
 		return false;
 	}
 	as_bytes* bytes = as_bytes_new_wrap(pk->buffer, pk->offset, true);
-	if (! bytes) {
-		as_packer_free_buffer(pk);
-		return false;
-	}
 	as_bin_init(&binop->bin, name, (as_bin_value*)bytes);
 	return true;
 }

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -14,14 +14,29 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
+// --------------------------------------------------------------------------------
+// Includes.
+
 #include <aerospike/as_cdt_internal.h>
 #include <aerospike/as_exp.h>
 #include <citrusleaf/alloc.h>
 #include <citrusleaf/cf_byte_order.h>
 #include "_bin.h"
 
+
+// --------------------------------------------------------------------------------
+// Forward declarations
+
+void
+as_packer_free_buffer(as_packer* pk);
+
 as_binop*
 as_binop_forappend(as_operations* ops, as_operator operator, const char* name);
+
+
+// --------------------------------------------------------------------------------
+// Public API
 
 void
 as_cdt_pack_header(as_packer* pk, as_cdt_ctx* ctx, uint16_t command, uint32_t count)
@@ -119,10 +134,14 @@ as_cdt_add_packed(as_packer* pk, as_operations* ops, const char* name, as_operat
 {
 	as_binop* binop = as_binop_forappend(ops, op_type, name);
 	if (! binop) {
-		cf_free(pk->buffer);
+		as_packer_free_buffer(pk);
 		return false;
 	}
 	as_bytes* bytes = as_bytes_new_wrap(pk->buffer, pk->offset, true);
+	if (! bytes) {
+		as_packer_free_buffer(pk);
+		return false;
+	}
 	as_bin_init(&binop->bin, name, (as_bin_value*)bytes);
 	return true;
 }
@@ -261,3 +280,29 @@ as_val_compare(as_val* v1, as_val* v2)
 	cf_free(s2);
 	return rv == 0;
 }
+
+// --------------------------------------------------------------------------------
+// Local helpers.
+
+/**
+ * @private Remove buffer attached to a packer.
+ *
+ * Typically invoked before returning an error in an outer function.
+ *
+ * Frees a buffer allocated by the as_cdt_end() macro and
+ * attached to a packer.  Note that packers are almost always
+ * stack-allocated, so we cannot free the whole packer itself;
+ * however, we can remove the subordinate buffer.
+ *
+ * This also NULLs out the buffer pointer, so that the packer can
+ * be re-used in a subsequent operation.
+ */
+void
+as_packer_free_buffer(as_packer* pk)
+{
+	if (pk->buffer) {
+		cf_free(pk->buffer);
+		pk->buffer = NULL;
+	}
+}
+

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -119,6 +119,7 @@ as_cdt_add_packed(as_packer* pk, as_operations* ops, const char* name, as_operat
 {
 	as_binop* binop = as_binop_forappend(ops, op_type, name);
 	if (! binop) {
+		cf_free(pk->buffer);
 		return false;
 	}
 	as_bytes* bytes = as_bytes_new_wrap(pk->buffer, pk->offset, true);

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -36,7 +36,7 @@ as_binop_forappend(as_operations* ops, as_operator operator, const char* name);
 // Local helpers.
 
 /**
- * @private Remove buffer attached to a packer.
+ * @private Remove buffer attached to an as_packer variable.
  *
  * Typically invoked before returning an error in an outer function.
  *

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -14,26 +14,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-// --------------------------------------------------------------------------------
-// Includes.
-
 #include <aerospike/as_cdt_internal.h>
 #include <aerospike/as_exp.h>
 #include <citrusleaf/alloc.h>
 #include <citrusleaf/cf_byte_order.h>
 #include "_bin.h"
 
-
-// --------------------------------------------------------------------------------
-// Forward declarations
-
 as_binop*
 as_binop_forappend(as_operations* ops, as_operator operator, const char* name);
-
-
-// --------------------------------------------------------------------------------
-// Local helpers.
 
 /**
  * @private Remove buffer attached to an as_packer variable.

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -58,9 +58,6 @@ as_packer_free_buffer(as_packer* pk)
 }
 
 
-// --------------------------------------------------------------------------------
-// Public API
-
 void
 as_cdt_pack_header(as_packer* pk, as_cdt_ctx* ctx, uint16_t command, uint32_t count)
 {

--- a/src/main/aerospike/as_cdt_internal.c
+++ b/src/main/aerospike/as_cdt_internal.c
@@ -28,11 +28,34 @@
 // --------------------------------------------------------------------------------
 // Forward declarations
 
-void
-as_packer_free_buffer(as_packer* pk);
-
 as_binop*
 as_binop_forappend(as_operations* ops, as_operator operator, const char* name);
+
+
+// --------------------------------------------------------------------------------
+// Local helpers.
+
+/**
+ * @private Remove buffer attached to a packer.
+ *
+ * Typically invoked before returning an error in an outer function.
+ *
+ * Frees a buffer allocated by the as_cdt_end() macro and
+ * attached to a packer.  Note that packers are almost always
+ * stack-allocated, so we cannot free the whole packer itself;
+ * however, we can remove the subordinate buffer.
+ *
+ * This also NULLs out the buffer pointer, so that the packer can
+ * be re-used in a subsequent operation.
+ */
+static inline void
+as_packer_free_buffer(as_packer* pk)
+{
+	if (pk->buffer) {
+		cf_free(pk->buffer);
+		pk->buffer = NULL;
+	}
+}
 
 
 // --------------------------------------------------------------------------------
@@ -275,30 +298,5 @@ as_val_compare(as_val* v1, as_val* v2)
 	cf_free(s1);
 	cf_free(s2);
 	return rv == 0;
-}
-
-// --------------------------------------------------------------------------------
-// Local helpers.
-
-/**
- * @private Remove buffer attached to a packer.
- *
- * Typically invoked before returning an error in an outer function.
- *
- * Frees a buffer allocated by the as_cdt_end() macro and
- * attached to a packer.  Note that packers are almost always
- * stack-allocated, so we cannot free the whole packer itself;
- * however, we can remove the subordinate buffer.
- *
- * This also NULLs out the buffer pointer, so that the packer can
- * be re-used in a subsequent operation.
- */
-void
-as_packer_free_buffer(as_packer* pk)
-{
-	if (pk->buffer) {
-		cf_free(pk->buffer);
-		pk->buffer = NULL;
-	}
 }
 

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -3938,6 +3938,37 @@ TEST(list_select_tree, "test select tree")
 	rec = NULL;
 }
 
+TEST(list_check_bin_name_length_handling, "test bin name length handling")
+{
+	// This test aims to reproduce an edge case found during Python testing,
+	// where as_cdt_end() causes memory to be allocated but not freed as a
+	// result of an error from as_cdt_add_packed().  See CLIENT-4704.
+
+//#define ERR_BIN_NAME	"I_am_bin_0123456789abcdefghijklmnopqrstuvwxyz"
+#define ERR_BIN_NAME	"I_am_bin_012345678"
+
+    as_arraylist list;
+    as_arraylist_inita(&list, 5);
+    as_arraylist_append_int64(&list, 40);
+    as_arraylist_append_int64(&list, 6);
+    as_arraylist_append_int64(&list, 13);
+    as_arraylist_append_int64(&list, 27);
+    as_arraylist_append_int64(&list, 33);
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 211);
+
+	as_record rec;
+    as_record_init(&rec, 1);
+    as_record_set_list(&rec, ERR_BIN_NAME, (as_list*)&list);
+
+	as_error err;
+	as_status status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+    as_record_destroy(&rec);
+
+#undef ERR_BIN_NAME
+}
 
 /******************************************************************************
  * TEST SUITE
@@ -3987,4 +4018,6 @@ SUITE(list_basics, "aerospike list basic tests")
 	suite_add(list_apply_remove);
 	suite_add(list_apply_remove2);
 	suite_add(list_select_tree);
+
+	suite_add(list_check_bin_name_length_handling);
 }

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -3944,30 +3944,61 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 	// where as_cdt_end() causes memory to be allocated but not freed as a
 	// result of an error from as_cdt_add_packed().  See CLIENT-4704.
 
-//#define ERR_BIN_NAME	"I_am_bin_0123456789abcdefghijklmnopqrstuvwxyz"
-#define ERR_BIN_NAME	"I_am_bin_012345678"
+	char long_bin_name[128];
+	memset(long_bin_name, 0, sizeof(long_bin_name));
+	sprintf(long_bin_name, "%s_toolong_0123456789", BIN_NAME);
 
-    as_arraylist list;
-    as_arraylist_inita(&list, 5);
-    as_arraylist_append_int64(&list, 40);
-    as_arraylist_append_int64(&list, 6);
-    as_arraylist_append_int64(&list, 13);
-    as_arraylist_append_int64(&list, 27);
-    as_arraylist_append_int64(&list, 33);
+	as_arraylist list;
+	as_arraylist_inita(&list, 5);
+	as_arraylist_append_int64(&list, 40);
+	as_arraylist_append_int64(&list, 6);
+	as_arraylist_append_int64(&list, 13);
+	as_arraylist_append_int64(&list, 27);
+	as_arraylist_append_int64(&list, 33);
 
 	as_key key;
 	as_key_init_int64(&key, NAMESPACE, SET, 211);
 
 	as_record rec;
-    as_record_init(&rec, 1);
-    as_record_set_list(&rec, ERR_BIN_NAME, (as_list*)&list);
+	as_record_init(&rec, 1);
+	as_record_set_list(&rec, BIN_NAME, (as_list*)&list);
 
 	as_error err;
 	as_status status = aerospike_key_put(as, &err, NULL, &key, &rec);
 	assert_int_eq(status, AEROSPIKE_OK);
-    as_record_destroy(&rec);
+	as_record_destroy(&rec);
 
-#undef ERR_BIN_NAME
+
+	as_integer v;
+	as_integer_init(&v, 11);
+	as_operations ops;
+	as_operations_inita(&ops, 2);
+	// Use deliberately bad bin name here;
+	// check with Valgrind to discover if leak is plugged.
+	as_operations_list_append(&ops, long_bin_name, NULL, NULL, (as_val*)&v);
+	as_operations_add_read(&ops, BIN_NAME);
+
+	as_record* prec = 0;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+
+	as_bin* results = prec->bins.entries;
+	int i = 0;
+
+	int64_t val = results[i++].valuep->integer.value;
+	assert_int_eq(val, 6);
+
+	as_list* l = &results[i++].valuep->list;
+	assert_int_eq(as_list_size(l), 6);
+	assert_int_eq(as_list_get_int64(l, 0), 40);
+	assert_int_eq(as_list_get_int64(l, 1), 6);
+	assert_int_eq(as_list_get_int64(l, 2), 13);
+	assert_int_eq(as_list_get_int64(l, 3), 27);
+	assert_int_eq(as_list_get_int64(l, 4), 33);
+	assert_int_eq(as_list_get_int64(l, 5), 11);
+
+	as_record_destroy(prec);
 }
 
 /******************************************************************************

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -3950,13 +3950,14 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 	sprintf(long_bin_name, "%s_toolong_0123456789", BIN_NAME);
 
 	// Stuff a list into a record.
+#define N_ELEMENTS 5
+	int64_t list_elements[N_ELEMENTS] = { 40, 6, 13, 27, 33 };
+
 	as_arraylist list;
-	as_arraylist_inita(&list, 5);
-	as_arraylist_append_int64(&list, 40);
-	as_arraylist_append_int64(&list, 6);
-	as_arraylist_append_int64(&list, 13);
-	as_arraylist_append_int64(&list, 27);
-	as_arraylist_append_int64(&list, 33);
+	as_arraylist_inita(&list, N_ELEMENTS);
+	for (int i = 0; i < N_ELEMENTS; i++) {
+		as_arraylist_append_int64(&list, list_elements[i]);
+	}
 
 	as_key key;
 	as_key_init_int64(&key, NAMESPACE, SET, 211);
@@ -4005,13 +4006,11 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 
 	assert_int_eq(as_bin_get_type(bin), AS_LIST);
 	as_list* l = (as_list*)as_bin_get_value(bin);
-	assert_int_eq(as_list_size(l), 5);
-	assert_int_eq(as_list_get_int64(l, 0), 40);
-	assert_int_eq(as_list_get_int64(l, 1), 6);
-	assert_int_eq(as_list_get_int64(l, 2), 13);
-	assert_int_eq(as_list_get_int64(l, 3), 27);
-	assert_int_eq(as_list_get_int64(l, 4), 33);
-
+	assert_int_eq(as_list_size(l), N_ELEMENTS);
+	for (int i = 0; i < N_ELEMENTS; i++) {
+		assert_int_eq(as_list_get_int64(l, i), list_elements[i]);
+	}
+#undef N_ELEMENTS
 	as_record_destroy(prec);
 }
 

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -3944,10 +3944,12 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 	// where as_cdt_end() causes memory to be allocated but not freed as a
 	// result of an error from as_cdt_add_packed().  See CLIENT-4704.
 
+	// First, compute a bin name that is too long to process.
 	char long_bin_name[128];
 	memset(long_bin_name, 0, sizeof(long_bin_name));
 	sprintf(long_bin_name, "%s_toolong_0123456789", BIN_NAME);
 
+	// Stuff a list into a record.
 	as_arraylist list;
 	as_arraylist_inita(&list, 5);
 	as_arraylist_append_int64(&list, 40);
@@ -3968,35 +3970,47 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 	assert_int_eq(status, AEROSPIKE_OK);
 	as_record_destroy(&rec);
 
-
+	// Next, create an operations list, where we try:
+	//
+	// 1. to append an element to a list via the long bin name, and,
+	// 2. to read back the list at the normal bin name.
+	//
+	// We expect the operation at step 1 to fail locally; however,
+	// we expect step 2 to succeed.
+	//
+	// Note that it was during step 1 that the memory leak occurred
+	// prior to fixing.
 	as_integer v;
 	as_integer_init(&v, 11);
 	as_operations ops;
 	as_operations_inita(&ops, 2);
-	// Use deliberately bad bin name here;
-	// check with Valgrind to discover if leak is plugged.
-	as_operations_list_append(&ops, long_bin_name, NULL, NULL, (as_val*)&v);
-	as_operations_add_read(&ops, BIN_NAME);
+	assert_int_eq(
+		as_operations_list_append(&ops, long_bin_name, NULL, NULL, (as_val*)&v),
+		false);
+	assert_int_eq(
+		as_operations_add_read(&ops, BIN_NAME),
+		true);
 
 	as_record* prec = 0;
 	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
 	assert_int_eq(status, AEROSPIKE_OK);
 	as_operations_destroy(&ops);
 
-	as_bin* results = prec->bins.entries;
-	int i = 0;
+	// List append on long_bin_name is expected to fail locally.
+	// However, the subsequent read operation is expected to succeed.
+	// As a result, the operations list is still initialized well enough
+	// to support one operation: the read-back of the list.
+	assert_int_eq(prec->bins.size, 1);
+	as_bin* bin = &prec->bins.entries[0];
 
-	int64_t val = results[i++].valuep->integer.value;
-	assert_int_eq(val, 6);
-
-	as_list* l = &results[i++].valuep->list;
-	assert_int_eq(as_list_size(l), 6);
+	assert_int_eq(as_bin_get_type(bin), AS_LIST);
+	as_list* l = (as_list*)as_bin_get_value(bin);
+	assert_int_eq(as_list_size(l), 5);
 	assert_int_eq(as_list_get_int64(l, 0), 40);
 	assert_int_eq(as_list_get_int64(l, 1), 6);
 	assert_int_eq(as_list_get_int64(l, 2), 13);
 	assert_int_eq(as_list_get_int64(l, 3), 27);
 	assert_int_eq(as_list_get_int64(l, 4), 33);
-	assert_int_eq(as_list_get_int64(l, 5), 11);
 
 	as_record_destroy(prec);
 }


### PR DESCRIPTION
## Extra Changes
- CI/CD: add smoke tests

## Notes

- Everywhere `as_cdt_add_packed` is called, a stack allocated `as_packer pk` is initialized with all zeroes and passed to that function
- New `list_check_bin_name_length_handling` test case passes
- In the Python client's CI/CD pipeline, valgrind no longer shows the memory leak