### PR TITLE
CLIENT-4758: API name changes

### DIFF
--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -128,8 +128,8 @@ typedef enum {
 	_AS_EXP_CODE_BIN_TYPE = 82,
 
 	_AS_EXP_CODE_REMOVE_RESULT = 100,
-	_AS_EXP_CODE_MAP_KEYS = 101,
-	_AS_EXP_CODE_MAP_VALUES = 102,
+	_AS_EXP_CODE_MAP_KEYS_IN = 101,
+	_AS_EXP_CODE_MAP_VALUES_IN = 102,
 
 	_AS_EXP_CODE_LOOPVAR = 122,
 
@@ -991,29 +991,41 @@ as_exp_destroy_base64(char* base64)
  * as_orderedmap_init(&m, 2);
  * as_orderedmap_set(&m, (as_val*)as_string_new((char*)"k", false),
  *     (as_val*)as_integer_new(1));
- * as_exp_build(e, as_exp_map_keys(as_exp_val((as_val*)&m)));
+ * as_exp_build(e, as_exp_map_keys_in(as_exp_val((as_val*)&m)));
  * as_exp_destroy(e);
  * as_orderedmap_destroy(&m);
  * @endcode
  *
+ * Note that this macro is also available under an older, deprecated name:
+ * @c as_exp_map_keys.
+ *
  * @param __map	Map-valued expression (e.g. bin or constant).
  * @return (list value)
  * @ingroup expression
  */
-#define as_exp_map_keys(__map) \
-		{.op=_AS_EXP_CODE_MAP_KEYS, .count=2}, __map
+#define as_exp_map_keys_in(__map) \
+		{.op=_AS_EXP_CODE_MAP_KEYS_IN, .count=2}, __map
+
+// Retain compatibility with 7.4.0 release
+#define as_exp_map_keys(__map)  as_exp_map_keys_in(__map)
 
 /**
  * Return a list of values from a map-valued subexpression.
  *
- * @a __map must evaluate to a map; see @ref as_exp_map_keys for operand forms.
+ * @a __map must evaluate to a map; see @ref as_exp_map_keys_in for operand forms.
+ *
+ * Note that this macro is also available under an older, deprecated name:
+ * @c as_exp_map_values.
  *
  * @param __map	Map-valued expression (e.g. bin or constant).
  * @return (list value)
  * @ingroup expression
  */
-#define as_exp_map_values(__map) \
-		{.op=_AS_EXP_CODE_MAP_VALUES, .count=2}, __map
+#define as_exp_map_values_in(__map) \
+		{.op=_AS_EXP_CODE_MAP_VALUES_IN, .count=2}, __map
+
+// Retain compatibility with 7.4.0 release
+#define as_exp_map_valies(__map)  as_exp_map_values_in(__map)
 
 /**
  * Create expression that performs a regex match on a string bin or value

--- a/src/test/exp_operate.c
+++ b/src/test/exp_operate.c
@@ -1054,7 +1054,7 @@ TEST(exp_in_list, "as_exp_in_list string and int membership")
 	}
 }
 
-TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
+TEST(exp_map_keys_values, "as_exp_map_keys_in and as_exp_map_values_in")
 {
 	as_error err;
 	as_status rc;
@@ -1089,10 +1089,10 @@ TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
 	as_bin* results;
 
 	/*------------------------------------------------------------------
-	 * Case 1: map_keys(as_exp_bin_map("m")) -> list containing "a", "b"
+	 * Case 1: map_keys_in(as_exp_bin_map("m")) -> list containing "a", "b"
 	 *----------------------------------------------------------------*/
 	{
-		as_exp_build(expr, as_exp_map_keys(as_exp_bin_map("m")));
+		as_exp_build(expr, as_exp_map_keys_in(as_exp_bin_map("m")));
 		assert_not_null(expr);
 
 		as_operations_inita(&ops, 1);
@@ -1126,10 +1126,10 @@ TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
 	}
 
 	/*------------------------------------------------------------------
-	 * Case 2: map_values(as_exp_bin_map("m")) -> list containing 1, 2
+	 * Case 2: map_values_in(as_exp_bin_map("m")) -> list containing 1, 2
 	 *----------------------------------------------------------------*/
 	{
-		as_exp_build(expr, as_exp_map_values(as_exp_bin_map("m")));
+		as_exp_build(expr, as_exp_map_values_in(as_exp_bin_map("m")));
 		assert_not_null(expr);
 
 		as_operations_inita(&ops, 1);
@@ -1161,7 +1161,7 @@ TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
 	}
 
 	/*------------------------------------------------------------------
-	 * Case 3: literal map — map_keys / map_values via as_exp_val
+	 * Case 3: literal map — map_keys_in / map_values_in via as_exp_val
 	 *----------------------------------------------------------------*/
 	{
 		as_orderedmap* lit = as_orderedmap_new(2);
@@ -1171,7 +1171,7 @@ TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
 		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"b", false),
 				(as_val*)as_integer_new(2));
 
-		as_exp_build(expr_k, as_exp_map_keys(as_exp_val((as_val*)lit)));
+		as_exp_build(expr_k, as_exp_map_keys_in(as_exp_val((as_val*)lit)));
 		assert_not_null(expr_k);
 		as_orderedmap_destroy(lit);
 
@@ -1213,7 +1213,7 @@ TEST(exp_map_keys_values, "as_exp_map_keys and as_exp_map_values")
 		as_orderedmap_set(lit, (as_val*)as_string_new((char*)"b", false),
 				(as_val*)as_integer_new(2));
 
-		as_exp_build(expr_v, as_exp_map_values(as_exp_val((as_val*)lit)));
+		as_exp_build(expr_v, as_exp_map_values_in(as_exp_val((as_val*)lit)));
 		assert_not_null(expr_v);
 		as_orderedmap_destroy(lit);
 


### PR DESCRIPTION
as_exp_map_keys -> as_exp_map_keys_in
as_exp_map_values -> as_exp_map_values_in

The old names are retained for backward compatibility as well, but should be removed in v8.0.0.