### PR TITLE
ci(workflows): add pull_request trigger, drop version override

### DIFF
--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 # workflow_call:
 #   inputs:

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -52,8 +52,6 @@ jobs:
       jf-project: ctest
       jf-build-name: ctest-build
       version: ${{ needs.extract-version.outputs.version }}
-      gh-source-path: repo-source
-      working-directory: repo-source/.github/workflows/execute-build/test_apps/hi
       gh-artifact-directory: packaged-artifacts
       matrix-json: >-
         {"include":[

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - master
+      - stage
 
 # workflow_call:
 #   inputs:
@@ -55,22 +55,54 @@ jobs:
       gh-artifact-directory: packaged-artifacts
       matrix-json: >-
         {"include":[
-          {"runs-on":"ubuntu-22.04","distro":"debian13","arch":"x86_64", "build-env":"EMULATED=false"},
-          {"runs-on":"ubuntu-22.04","distro":"jammy","arch":"x86_64", "build-env":"EMULATED=false"},
+          # Debian Intel
+          {
+            "runs-on":"ubuntu-22.04",
+            "distro":"debian13",
+            "arch":"x86_64",
+            "build-env":"EMULATED=false",
+            "build-script": |
+              # matrix-json is injected into the environment as MATRIX_JSON
+              # we can use jq to extract the values we need
+              export DISTRO=$(jq -r '.distro' <<<"$MATRIX_JSON")
+              export ARCH=$(jq -r '.arch' <<<"$MATRIX_JSON")
+              # emulated is set in the environment by the reusable_artifacts-cicd.yaml workflow
+              export EMULATED=$EMULATED
+              echo "DISTRO: $DISTRO"
+              echo "ARCH: $ARCH"
+              echo "EMULATED: $EMULATED"
+              env | sort
+              sudo apt-get install autoconf automake g++ libc6-dev libssl-dev libtool libyaml-dev zlib1g-dev
+              make clean
+              make
+              sudo make install
+              make package
+          },
+          # Ubuntu Intel
+          {
+            "runs-on":"ubuntu-22.04",
+            "distro":"jammy",
+            "arch":"x86_64",
+            "build-env":"EMULATED=false",
+            "build-script": |
+              # matrix-json is injected into the environment as MATRIX_JSON
+              # we can use jq to extract the values we need
+              export DISTRO=$(jq -r '.distro' <<<"$MATRIX_JSON")
+              export ARCH=$(jq -r '.arch' <<<"$MATRIX_JSON")
+              # emulated is set in the environment by the reusable_artifacts-cicd.yaml workflow
+              export EMULATED=$EMULATED
+              echo "DISTRO: $DISTRO"
+              echo "ARCH: $ARCH"
+              echo "EMULATED: $EMULATED"
+              env | sort
+              sudo apt-get install autoconf automake g++ libc6-dev libssl-dev libtool libyaml-dev zlib1g-dev
+              sudo apt-get install ncurses-dev
+              make clean
+              make
+              sudo make install
+              make package
+          },
         ]}
-      build-script: |
-        # matrix-json is injected into the environment as MATRIX_JSON
-        # we can use jq to extract the values we need
-        export DISTRO=$(jq -r '.distro' <<<"$MATRIX_JSON")
-        export ARCH=$(jq -r '.arch' <<<"$MATRIX_JSON")
-        # emulated is set in the environment by the reusable_artifacts-cicd.yaml workflow
-        export EMULATED=$EMULATED
-        echo "DISTRO: $DISTRO"
-        echo "ARCH: $ARCH"
-        echo "EMULATED: $EMULATED"
-        env | sort
-        make clean && make && sudo make install
-        make package
       oidc-provider-name: gh-aerospike
       oidc-audience: aerospike
       dry-run: false
@@ -138,8 +170,9 @@ jobs:
           deb [arch=$ARCH signed-by=$KEYRING] https://$REPO $CODENAME main
           EOF
 
+          echo "FAILURE EXPECTED HERE"
+          echo "I know this is the wrong package to install...need to find out the right one"
           sudo apt-get update && sudo apt-get install hi -y
-          echo "OK, now what?"
 
 #  use-rpm-artifacts:
 #    runs-on: ubuntu-22.04

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -48,7 +48,7 @@ jobs:
     uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.4.1
     needs: extract-version
     with:
-      gh-workflows-ref: ${{ github.sha }}
+      gh-workflows-ref: v3.4.1
       jf-project: ctest
       jf-build-name: ctest-build
       version: ${{ needs.extract-version.outputs.version }}

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -1,7 +1,5 @@
 name: Example Artifacts CI/CD
 on:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
   pull_request:
     branches:

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - main
+      - master
 
 # workflow_call:
 #   inputs:

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -3,12 +3,6 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
-    inputs:
-      version:
-        description: Version override (leave empty for auto-detection)
-        required: false
-        default: ""
-        type: string
 
 # workflow_call:
 #   inputs:
@@ -28,7 +22,6 @@ concurrency:
   group: jfrog-test-deploy
   cancel-in-progress: false
 
-# This workflow demonstrates a drop-in artifacts pipeline using reusable_artifacts-cicd.yaml
 
 jobs:
   extract-version:
@@ -42,9 +35,6 @@ jobs:
       - name: Extract Version
         id: extract
         uses: ./.github/actions/extract-version-from-tag
-        with:
-          version: ${{ inputs.version }}
-          version-prefix: ""
 
     outputs:
       version: ${{ steps.extract.outputs.version }}

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -73,8 +73,8 @@ jobs:
         env | sort
         make clean && make && sudo make install
         make package
-      oidc-provider-name: gh-dev-ctest
-      oidc-audience: aerospike/testing
+      oidc-provider-name: gh-aerospike
+      oidc-audience: aerospike
       dry-run: false
       # sign-mac: true
       # mac-signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"

--- a/.github/workflows/something.yml
+++ b/.github/workflows/something.yml
@@ -33,10 +33,13 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Extract Version
+        with:
+          # Full history + tags so `git describe --tags` can resolve the
+          # nearest release tag instead of falling through to 0.0.0-dev+<sha>.
+          fetch-depth: 0
+      - name: Extract version
         id: extract
-        uses: ./.github/actions/extract-version-from-tag
-
+        uses: aerospike/shared-workflows/.github/actions/extract-version-from-tag@07c958ca4c5cea494dc8790949c08e3fb28c55e1 # v3.3.0
     outputs:
       version: ${{ steps.extract.outputs.version }}
       git_tag: ${{ steps.extract.outputs.git_tag }}


### PR DESCRIPTION
## Summary

Switches `something.yml` to also run on pull requests targeting `main`, alongside the existing `issue_comment` and `workflow_dispatch` triggers. Drops the manual `version` input from `workflow_dispatch` and stops forwarding it to the `extract-version-from-tag` action, since auto-detection already covers it.

## Changes

- Add `pull_request` trigger on `main`
- Remove `version` input from `workflow_dispatch` and from the extract-version action call
- Drop a stale comment referencing the demo pipeline

## Test plan

This PR targets `CLIENT-4299-workflow-test-1`, so the new `pull_request` trigger will not fire here. Validation: after this branch is merged into a branch that gets opened as a PR against `main`, confirm the workflow fires and that `extract-version` resolves a version from auto-detection.