### PR TITLE
Batch: error-details opt-in + per-record parse (CLIENT-3986)

### DIFF
--- a/examples/basic_examples/error_message/src/main/example.c
+++ b/examples/basic_examples/error_message/src/main/example.c
@@ -58,8 +58,10 @@
 #include <string.h>
 
 #include <aerospike/aerospike.h>
+#include <aerospike/aerospike_batch.h>
 #include <aerospike/aerospike_key.h>
 #include <aerospike/as_arraylist.h>
+#include <aerospike/as_batch.h>
 #include <aerospike/as_bit_operations.h>
 #include <aerospike/as_cdt_ctx.h>
 #include <aerospike/as_error.h>
@@ -74,6 +76,7 @@
 #include <aerospike/as_record.h>
 #include <aerospike/as_status.h>
 #include <aerospike/as_string.h>
+#include <aerospike/as_vector.h>
 
 #include "example_utils.h"
 
@@ -1003,6 +1006,126 @@ check_case(const error_case* c, as_status got, const as_error* err)
 	return ok;
 }
 
+//==========================================================
+// Batch error-details checks.
+//
+// Batch surfaces per-row detail differently from single-record: the server
+// serializes field 45 into each error row's reply, and the client folds it into
+// that record's error_subcode / error_message (NOT the top-level as_error). The
+// opt-in is batch-wide via the parent batch policy's error_detail_verbosity.
+// These checks run a mixed-row batch and assert: an error row carries the per-
+// row detail when opted in, a success row carries none, and opt-in OFF carries
+// none. Returns the number of failed checks.
+//
+
+static uint32_t
+run_batch_cases(aerospike* as)
+{
+	uint32_t failed = 0;
+	as_error err;
+
+	as_key k_err;
+	as_key k_ok;
+	as_key_init(&k_err, g_namespace, g_set, "edk-batch-err");
+	as_key_init(&k_ok, g_namespace, g_set, "edk-batch-ok");
+	put_int(as, &k_err, 1);
+	put_int(as, &k_ok, 1);
+
+	// Append a string to an int bin -> bin-incompatible error on that row.
+	as_operations bad;
+	as_operations_inita(&bad, 1);
+	as_operations_add_append_str(&bad, BIN, "bad");
+
+	// A valid increment -> success row.
+	as_operations good;
+	as_operations_inita(&good, 1);
+	as_operations_add_incr(&good, BIN, 1);
+
+	// --- opt-in ON: detail rides the error row only. ---
+	as_policy_batch bp;
+	as_policy_batch_init(&bp);
+	bp.base.error_detail_verbosity = 2;
+	bp.respond_all_keys = true; // per-record mode: every row (incl. error) sent
+
+	as_batch_records recs;
+	as_batch_records_inita(&recs, 2);
+
+	as_batch_write_record* w0 = as_batch_write_reserve(&recs);
+	as_key_init(&w0->key, g_namespace, g_set, "edk-batch-err");
+	w0->ops = &bad;
+
+	as_batch_write_record* w1 = as_batch_write_reserve(&recs);
+	as_key_init(&w1->key, g_namespace, g_set, "edk-batch-ok");
+	w1->ops = &good;
+
+	aerospike_batch_write(as, &err, &bp, &recs);
+
+	as_batch_base_record* e = (as_batch_base_record*)as_vector_get(&recs.list, 0);
+	as_batch_base_record* o = (as_batch_base_record*)as_vector_get(&recs.list, 1);
+
+	// The bin-incompatible error is authored AS_SUB_NONE + message, so the
+	// per-row detail is message-only (subcode legitimately absent). Asserting
+	// the message rode proves field 45 round-tripped per record.
+	if (e->result == AEROSPIKE_OK) {
+		LOG("FAIL batch_optin_error_row: row unexpectedly succeeded");
+		failed++;
+	}
+	else if (e->error_message == NULL || e->error_message[0] == 0) {
+		LOG("FAIL batch_optin_error_row: missing per-row message (result=%d)",
+				e->result);
+		failed++;
+	}
+	else {
+		LOG("PASS batch_optin_error_row (result=%d subcode=%u msg='%s')",
+				e->result, e->error_subcode, e->error_message);
+	}
+
+	if (o->error_subcode != 0 || o->error_message != NULL) {
+		LOG("FAIL batch_success_row: unexpected detail (subcode=%u msg=%s)",
+				o->error_subcode,
+				o->error_message ? o->error_message : "(null)");
+		failed++;
+	}
+	else {
+		LOG("PASS batch_success_row");
+	}
+
+	as_batch_records_destroy(&recs);
+
+	// --- opt-in OFF: no detail anywhere (byte-identical legacy reply). ---
+	as_policy_batch bp_off;
+	as_policy_batch_init(&bp_off);
+	bp_off.base.error_detail_verbosity = 0;
+	bp_off.respond_all_keys = true;
+
+	as_batch_records recs2;
+	as_batch_records_inita(&recs2, 1);
+	as_batch_write_record* w2 = as_batch_write_reserve(&recs2);
+	as_key_init(&w2->key, g_namespace, g_set, "edk-batch-err");
+	w2->ops = &bad;
+
+	aerospike_batch_write(as, &err, &bp_off, &recs2);
+
+	as_batch_base_record* e2 = (as_batch_base_record*)as_vector_get(&recs2.list, 0);
+
+	if (e2->error_subcode != 0 || e2->error_message != NULL) {
+		LOG("FAIL batch_optin_off: detail leaked at verbosity 0 (subcode=%u)",
+				e2->error_subcode);
+		failed++;
+	}
+	else {
+		LOG("PASS batch_optin_off");
+	}
+
+	as_batch_records_destroy(&recs2);
+	as_operations_destroy(&bad);
+	as_operations_destroy(&good);
+	as_key_destroy(&k_err);
+	as_key_destroy(&k_ok);
+
+	return failed;
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -1042,10 +1165,17 @@ main(int argc, char* argv[])
 		}
 	}
 
+	// Batch per-row error details (separate harness - details land per record,
+	// not in the top-level as_error).
+	LOG("--- batch ---");
+	uint32_t batch_failed = run_batch_cases(&as);
+	failed += batch_failed;
+
 	example_cleanup(&as);
 
 	LOG("---");
-	LOG("%u passed, %u failed (of %u cases)", passed, failed, N_CASES);
+	LOG("%u passed, %u failed (of %u single-record cases + 3 batch checks)",
+			passed, failed, N_CASES);
 
 	return failed == 0 ? 0 : 1;
 }

--- a/src/include/aerospike/aerospike_batch.h
+++ b/src/include/aerospike/aerospike_batch.h
@@ -99,6 +99,20 @@ typedef struct as_batch_base_record_s {
 	 * to the server.
 	 */
 	bool in_doubt;
+
+	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed by
+	 * as_batch_records_destroy().
+	 */
+	char* error_message;
 } as_batch_base_record;
 
 /**
@@ -114,6 +128,20 @@ typedef struct as_batch_read_record_s {
 	as_batch_type type;
 	bool has_write;
 	bool in_doubt; // Will always be false for reads.
+
+	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed by
+	 * as_batch_records_destroy().
+	 */
+	char* error_message;
 
 	/**
 	 * Optional read policy.
@@ -165,6 +193,20 @@ typedef struct as_batch_write_record_s {
 	bool in_doubt;
 
 	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed by
+	 * as_batch_records_destroy().
+	 */
+	char* error_message;
+
+	/**
 	 * Optional write policy.
 	 */
 	const as_policy_batch_write* policy;
@@ -194,6 +236,20 @@ typedef struct as_batch_apply_record_s {
 	as_batch_type type;
 	bool has_write;
 	bool in_doubt;
+
+	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed by
+	 * as_batch_records_destroy().
+	 */
+	char* error_message;
 
 	/**
 	 * Optional apply policy.
@@ -237,6 +293,20 @@ typedef struct as_batch_remove_record_s {
 	as_batch_type type;
 	bool has_write;
 	bool in_doubt;
+
+	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed by
+	 * as_batch_records_destroy().
+	 */
+	char* error_message;
 
 	/**
 	 * Optional remove policy.

--- a/src/include/aerospike/as_batch.h
+++ b/src/include/aerospike/as_batch.h
@@ -91,6 +91,20 @@ typedef struct as_batch_result_s {
 	 * after the command was sent to the server.
 	 */
 	bool in_doubt;
+
+	/**
+	 * Server error subcode for this record, or zero when absent. Set only when
+	 * result is not AEROSPIKE_OK and the client requested error details via
+	 * as_policy_base.error_detail_verbosity.
+	 */
+	uint32_t error_subcode;
+
+	/**
+	 * Server error detail message for this record, or NULL when absent. Set only
+	 * when result is not AEROSPIKE_OK and error_detail_verbosity >= 2. Freed when
+	 * the batch results are released.
+	 */
+	char* error_message;
 } as_batch_result;
 
 /**

--- a/src/include/aerospike/as_command.h
+++ b/src/include/aerospike/as_command.h
@@ -694,6 +694,19 @@ as_command_parse_fields_error(uint8_t** pp, as_error* err, as_msg* msg);
 
 /**
  * @private
+ * Parse an error-details field (type 45) payload into raw subcode/message
+ * out-params. *subcode is set to zero and *message to NULL when the
+ * corresponding map key is absent. *message is heap-allocated and owned by the
+ * caller (any existing non-NULL *message is freed first). Used by batch, which
+ * stores error details per record rather than in a single as_error.
+ */
+as_status
+as_command_parse_error_details_values(
+	const uint8_t* buf, uint32_t len, uint32_t* subcode, char** message
+	);
+
+/**
+ * @private
  * Parse record fields given key.
  */
 static inline as_status

--- a/src/main/aerospike/aerospike_batch.c
+++ b/src/main/aerospike/aerospike_batch.c
@@ -293,6 +293,27 @@ as_batch_parse_record(uint8_t** pp, as_error* err, as_msg* msg, as_record* rec, 
 	return AEROSPIKE_OK;
 }
 
+// Walk a response row's fields for the error-details field (type 45) and capture
+// its subcode/message into the per-record out-params. The field rides only on
+// error rows that the client opted into; callers invoke this only when the row's
+// result is not AEROSPIKE_OK. The fields region is the same one as_command_parse_fields()
+// reads, so this must be called with the pre-walk field pointer.
+static void
+as_batch_parse_error_details(uint8_t* p, as_msg* msg, uint32_t* subcode, char** message)
+{
+	for (uint32_t i = 0; i < msg->n_fields; i++) {
+		uint32_t len = cf_swap_from_be32(*(uint32_t*)p) - 1;
+		p += sizeof(uint32_t);
+		uint8_t type = *p++;
+
+		if (type == AS_FIELD_ERROR_MESSAGE && len > 0) {
+			as_command_parse_error_details_values(p, len, subcode, message);
+		}
+
+		p += len;
+	}
+}
+
 static void
 as_batch_complete_async(as_event_executor* executor)
 {
@@ -365,6 +386,7 @@ as_batch_async_parse_records(as_event_command* cmd)
 		
 		as_batch_base_record* rec = as_vector_get(records, offset);
 
+		uint8_t* fields = p;
 		as_status status = as_command_parse_fields(&p, &err, msg, cmd->txn, &rec->key, rec->has_write);
 
 		if (status != AEROSPIKE_OK) {
@@ -372,6 +394,11 @@ as_batch_async_parse_records(as_event_command* cmd)
 		}
 
 		rec->result = msg->result_code;
+
+		if (msg->result_code != AEROSPIKE_OK) {
+			as_batch_parse_error_details(fields, msg, &rec->error_subcode,
+				&rec->error_message);
+		}
 
 		if (msg->result_code == AEROSPIKE_OK) {
 			as_status status = as_batch_parse_record(&p, &err, msg, &rec->record,
@@ -438,6 +465,7 @@ as_batch_parse_records(as_error* err, as_command* cmd, as_node* node, uint8_t* b
 				as_batch_task_records* btr = (as_batch_task_records*)task;
 				as_batch_base_record* rec = as_vector_get(btr->records, offset);
 
+				uint8_t* fields = p;
 				as_status status = as_command_parse_fields(&p, err, msg, txn, &rec->key, rec->has_write);
 
 				if (status != AEROSPIKE_OK) {
@@ -445,6 +473,11 @@ as_batch_parse_records(as_error* err, as_command* cmd, as_node* node, uint8_t* b
 				}
 
 				rec->result = msg->result_code;
+
+				if (msg->result_code != AEROSPIKE_OK) {
+					as_batch_parse_error_details(fields, msg, &rec->error_subcode,
+						&rec->error_message);
+				}
 
 				if (msg->result_code == AEROSPIKE_OK) {
 					status = as_batch_parse_record(&p, err, msg, &rec->record, deserialize);
@@ -475,6 +508,7 @@ as_batch_parse_records(as_error* err, as_command* cmd, as_node* node, uint8_t* b
 				as_batch_task_keys* btk = (as_batch_task_keys*)task;
 				as_batch_result* res = &btk->results[offset];
 
+				uint8_t* fields = p;
 				as_status status = as_command_parse_fields(&p, err, msg, txn, res->key, btk->base.has_write);
 
 				if (status != AEROSPIKE_OK) {
@@ -482,6 +516,11 @@ as_batch_parse_records(as_error* err, as_command* cmd, as_node* node, uint8_t* b
 				}
 
 				res->result = msg->result_code;
+
+				if (msg->result_code != AEROSPIKE_OK) {
+					as_batch_parse_error_details(fields, msg, &res->error_subcode,
+						&res->error_message);
+				}
 
 				if (msg->result_code == AEROSPIKE_OK) {
 					status = as_batch_parse_record(&p, err, msg, &res->record, deserialize);
@@ -1081,7 +1120,10 @@ as_batch_apply_record_size(as_batch_apply_record* rec, as_batch_builder* bb)
 static inline void
 as_batch_remove_record_size(as_batch_builder* bb)
 {
-	bb->size += 6; // gen(2) + ttl(4)
+	// Always account for the info4 byte even though it's rarely used, matching the
+	// write/apply sizers. It rides when on_locking_only or error-details verbosity
+	// is set on the row.
+	bb->size += 7; // gen(2) + ttl(4) + info4(1)
 }
 
 static inline void
@@ -1747,6 +1789,12 @@ as_batch_records_write_new(
 	uint64_t ver_prev = 0;
 	as_batch_attr attr;
 
+	// Batch-wide per-row error-details opt-in, from the parent batch policy. ORed
+	// into each non-repeat row's info4 below; repeat rows reuse the previous
+	// row's serialized info4 and therefore inherit the same verbosity.
+	uint8_t error_verbosity = (uint8_t)(policy->base.error_detail_verbosity <<
+			AS_MSG_INFO4_ERROR_VERBOSITY_SHIFT);
+
 	for (uint32_t i = 0; i < n_offsets; i++) {
 		uint32_t offset = *(uint32_t*)as_vector_get(offsets, i);
 		*(uint32_t*)p = cf_swap_to_be32(offset);
@@ -1774,6 +1822,8 @@ as_batch_records_write_new(
 					else {
 						as_batch_attr_read_header(&attr, policy);
 					}
+
+					attr.txn_attr |= error_verbosity;
 
 					if (br->bin_names) {
 						p = as_batch_write_bin_names(p, &br->key, txn, ver, &attr, attr.filter_exp,
@@ -1818,6 +1868,7 @@ as_batch_records_write_new(
 					}
 
 					as_batch_attr_write(&attr, bw->ops, pbw, send_key, durable_delete);
+					attr.txn_attr |= error_verbosity;
 					p = as_batch_write_operations(p, &bw->key, txn, ver, &attr, attr.filter_exp, bw->ops,
 						bb->buffers);
 					break;
@@ -1850,6 +1901,7 @@ as_batch_records_write_new(
 					}
 
 					as_batch_attr_apply(&attr, pba, send_key, durable_delete);
+					attr.txn_attr |= error_verbosity;
 					p = as_batch_write_udf(p, &ba->key, txn, ver, ba, &attr, attr.filter_exp, bb->buffers);
 					break;
 				}
@@ -1881,6 +1933,7 @@ as_batch_records_write_new(
 					}
 
 					as_batch_attr_remove(&attr, pbr, send_key, durable_delete);
+					attr.txn_attr |= error_verbosity;
 					p = as_batch_write_write(p, &brm->key, txn, ver, &attr, attr.filter_exp, 0, 0);
 					break;
 				}
@@ -3191,7 +3244,14 @@ as_batch_keys_execute(
 	as_cluster* cluster = as->cluster;
 	as_cluster_add_command_count(cluster);
 	uint32_t n_keys = batch->keys.size;
-	
+
+	// Per-row error-details opt-in is batch-wide, driven by the parent batch
+	// policy. Fold it into the shared row attributes here so every key-based
+	// command (simple get/operate/apply/remove and the keys batch API) carries
+	// the verbosity bits in its info4.
+	attr->txn_attr |= (uint8_t)(policy->base.error_detail_verbosity <<
+			AS_MSG_INFO4_ERROR_VERBOSITY_SHIFT);
+
 	if (n_keys == 0) {
 		destroy_versions(versions);
 
@@ -3240,6 +3300,8 @@ as_batch_keys_execute(
 		result->key = key;
 		result->result = AEROSPIKE_NO_RESPONSE;
 		result->in_doubt = false;
+		result->error_subcode = 0;
+		result->error_message = NULL;
 		as_record_init(&result->record, 0);
 
 		status = as_key_set_digest(err, key);
@@ -3382,6 +3444,7 @@ as_batch_keys_execute(
 	for (uint32_t i = 0; i < n_keys; i++) {
 		as_batch_result* br = &btk.results[i];
 		as_record_destroy(&br->record);
+		cf_free(br->error_message);
 	}
 	batch_results_free(results, n_keys);
 
@@ -5040,9 +5103,10 @@ as_batch_records_destroy(as_batch_records* records)
 	
 	for (uint32_t i = 0; i < list->size; i++) {
 		as_batch_base_record* record = as_vector_get(list, i);
-		
+
 		as_key_destroy(&record->key);
 		as_record_destroy(&record->record);
+		cf_free(record->error_message);
 	}
 	as_vector_destroy(list);
 }

--- a/src/main/aerospike/as_command.c
+++ b/src/main/aerospike/as_command.c
@@ -1251,6 +1251,88 @@ as_command_parse_error_details(const uint8_t* buf, uint32_t len, as_error* err)
 }
 
 as_status
+as_command_parse_error_details_values(
+	const uint8_t* buf, uint32_t len, uint32_t* subcode, char** message
+	)
+{
+	// Extract the raw subcode/message from a field-45 payload for callers (batch)
+	// that store details per record instead of folding them into one as_error.
+	// *subcode is set to 0 and *message to NULL when the map key is absent.
+	// *message is heap-allocated and owned by the caller; any existing non-NULL
+	// *message is freed first so a parse on retry does not leak.
+	*subcode = 0;
+
+	if (*message != NULL) {
+		cf_free(*message);
+		*message = NULL;
+	}
+
+	if (buf == NULL || len == 0) {
+		return AEROSPIKE_OK;
+	}
+
+	as_unpacker pk = {
+			.buffer = buf,
+			.offset = 0,
+			.length = len
+	};
+
+	int64_t count = as_unpack_map_header_element_count(&pk);
+
+	if (count <= 0) {
+		return AEROSPIKE_OK;
+	}
+
+	for (int64_t i = 0; i < count; i++) {
+		uint64_t key;
+
+		if (as_unpack_uint64(&pk, &key) != 0) {
+			return AEROSPIKE_OK;
+		}
+
+		switch (key) {
+		case AS_ERROR_DETAIL_KEY_MESSAGE: {
+			uint32_t str_sz = 0;
+			const uint8_t* str = as_unpack_str(&pk, &str_sz);
+
+			if (str == NULL) {
+				if (as_unpack_size(&pk) < 0) {
+					return AEROSPIKE_OK;
+				}
+				break;
+			}
+
+			uint32_t message_len = str_sz > AS_ERROR_MESSAGE_MAX_LEN ?
+					AS_ERROR_MESSAGE_MAX_LEN : str_sz;
+			char* m = cf_malloc(message_len + 1);
+
+			memcpy(m, str, message_len);
+			m[message_len] = 0;
+			*message = m;
+			break;
+		}
+		case AS_ERROR_DETAIL_KEY_SUBCODE: {
+			uint64_t sc = 0;
+
+			if (as_unpack_uint64(&pk, &sc) != 0) {
+				return AEROSPIKE_OK;
+			}
+
+			*subcode = (uint32_t)sc;
+			break;
+		}
+		default:
+			if (as_unpack_size(&pk) < 0) {
+				return AEROSPIKE_OK;
+			}
+			break;
+		}
+	}
+
+	return AEROSPIKE_OK;
+}
+
+as_status
 as_command_parse_fields_txn(
 	uint8_t** pp, as_error* err, as_msg* msg, as_txn* txn, const uint8_t* digest, const char* set,
 	bool is_write


### PR DESCRIPTION
## Batch — request error-details opt-in + per-record parse (CLIENT-3986)

Companion to server **SERVER-1144** (citrusleaf/aerospike-server + aerospike-server-enterprise `dylan/batch-error-details`). Surfaces per-row batch error details to the application.

### Changes
- **Request opt-in:** fold the parent batch policy's `error_detail_verbosity` into each row's `info4` — in `as_batch_keys_execute` (covers the simple `aerospike_batch_*` APIs and the keys batch API) and per row in `as_batch_records_write_new` (the records API). The verbosity is batch-wide because the per-record sub-policies (`as_policy_batch_read/write/apply/remove`) have no `as_policy_base`; only the parent `as_policy_batch` does. Reserve the info4 byte in `as_batch_remove_record_size` to match the other sizers.
- **Response surfacing:** add `error_subcode` + `error_message` to the batch record structs (`as_batch_base_record` and the read/write/apply/remove records, kept at the same offset for the union/base-cast; plus the keys-API `as_batch_result`). Parse field 45 per row into them; free `error_message` in the destroy paths.
- `as_command_parse_error_details_values()`: extract the raw subcode/message for the per-record path (the single-record path still folds the detail into `as_error`).
- `error_message` example: `run_batch_cases` exercising opt-in ON (per-record detail) / success row / opt-in OFF.

### Note for consumers
`error_subcode` may be `0` (`AS_SUB_NONE`) for message-only details — check `error_message` for presence rather than the subcode. Details ride only on error rows when opted in, and require a per-record batch mode (`respond_all_keys` / report-error-rec) to be delivered.

### Testing
Library builds clean. The `error_message` driver passes 28/28 single-record + 3/3 batch checks against a live cluster running the matching server build.
