### PR TITLE
[CLIENT-3809]: fix tls name memory leak in as_config_add_hosts

### DIFF
--- a/src/main/aerospike/as_config.c
+++ b/src/main/aerospike/as_config.c
@@ -263,16 +263,18 @@ as_config_add_hosts(as_config* config, const char* string, uint16_t default_port
 			if (more) {
 				if (! isdigit(*p)) {
 					cf_free(host.name);
+					cf_free(host.tls_name);
 					return false;
 				}
 				host.port = (uint16_t)strtol(p, (char**)&p, 10);
-				
+
 				if (*p) {
 					if (*p == ',') {
 						p++;
 					}
 					else {
 						cf_free(host.name);
+						cf_free(host.tls_name);
 						return false;
 					}
 				}

--- a/src/test/config_basics.c
+++ b/src/test/config_basics.c
@@ -161,6 +161,32 @@ TEST(config_set_user_both_oversized, "as_config_set_user() rejects oversized use
 	assert_config_unchanged(__result__, &config, user_snapshot, password_snapshot);
 }
 
+TEST(config_add_hosts_tls_name_bad_port, "as_config_add_hosts() frees tls_name when the port after it is invalid")
+{
+	as_config config;
+	as_config_init(&config);
+
+	// "host:tlsname:<non-digit>" hits the tls_name-then-invalid-port error path.
+	assert_false(as_config_add_hosts(&config, "myhost:mytls:notaport", 3000));
+	assert_not_null(config.hosts);
+	assert_int_eq(config.hosts->size, 0);
+
+	as_config_destroy(&config);
+}
+
+TEST(config_add_hosts_tls_name_trailing_garbage, "as_config_add_hosts() frees tls_name when trailing garbage follows the port")
+{
+	as_config config;
+	as_config_init(&config);
+
+	// "host:tlsname:<port><garbage>" hits the tls_name-then-trailing-garbage error path.
+	assert_false(as_config_add_hosts(&config, "myhost:mytls:3000x", 3000));
+	assert_not_null(config.hosts);
+	assert_int_eq(config.hosts->size, 0);
+
+	as_config_destroy(&config);
+}
+
 SUITE(config_basics, "aerospike config tests")
 {
 	suite_add(config_set_user_valid);
@@ -169,4 +195,6 @@ SUITE(config_basics, "aerospike config tests")
 	suite_add(config_set_user_oversized_user);
 	suite_add(config_set_user_oversized_password);
 	suite_add(config_set_user_both_oversized);
+	suite_add(config_add_hosts_tls_name_bad_port);
+	suite_add(config_add_hosts_tls_name_trailing_garbage);
 }


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-3809

## Summary

Fixes a memory leak in `as_config_add_hosts()` when host strings contain a TLS name followed by a malformed port or trailing garbage (e.g., `"host:tlsname:badport"`).

## Changes

Added missing `cf_free(host.tls_name)` alongside `cf_free(host.name)` on both error cleanup paths in `as_config_add_hosts()`.

## Test Plan

* [x] **Added Regression Tests:** Added `config_add_hosts_tls_name_bad_port` and `config_add_hosts_tls_name_trailing_garbage` to `src/test/config_basics.c`, covering both malformed host-string shapes.
* [x] **Leak Verification:** Verified using macOS `leaks` tool (standalone harness on Apple Silicon):
* **Before:** 2 leaks / 32 bytes
* **After:** 0 leaks

* [x] **Test Suite:** Full local test suite passes (441/441).