### PR TITLE
[CLIENT-2479]: Disallow use of add_ops and UDF apply

### DIFF
--- a/src/main/aerospike/aerospike_query.c
+++ b/src/main/aerospike/aerospike_query.c
@@ -2538,6 +2538,11 @@ aerospike_query_background(
 			"Background function or ops is required");
 	}
 
+	if (query->ops && query->apply.function[0]) {
+		return as_error_set_message(err, AEROSPIKE_ERR_PARAM,
+			"Cannot combine query operations with aggregation");
+	}
+
 	if (query->ops && !as_operations_consists_of_all_writes(query->ops)) {
 		return as_error_set_message(err, AEROSPIKE_ERR_PARAM,
 			"Background query operations must be write-only. Use query for read-only operations.");

--- a/src/main/aerospike/aerospike_scan.c
+++ b/src/main/aerospike/aerospike_scan.c
@@ -814,6 +814,11 @@ static inline as_status
 as_scan_validate(as_error* err, const as_policy_scan* policy, const as_scan* scan)
 {
 	as_error_reset(err);
+
+	if (scan->ops && scan->apply_each.function[0]) {
+		return as_error_set_message(err, AEROSPIKE_ERR_PARAM,
+			"Cannot combine scan operations with a UDF");
+	}
 	return AEROSPIKE_OK;
 }
 

--- a/src/test/aerospike_query/query_background.c
+++ b/src/test/aerospike_query/query_background.c
@@ -526,6 +526,35 @@ TEST(query_operate_ttl, "query operate ttl")
 	as_record_destroy(rec);
 }
 
+TEST(query_background_ops_and_apply_rejected, "background query rejects combined ops and UDF apply")
+{
+	as_error err;
+	as_status status;
+	as_query q;
+
+	as_query_init(&q, NAMESPACE, SET);
+	as_query_where_inita(&q, 1);
+	as_query_where(&q, "qebin1", as_integer_range(3, 9));
+
+	as_string str;
+	as_string_init(&str, "bar", false);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_add_write(&ops, "foo", (as_bin_value*)&str);
+	q.ops = &ops;
+
+	as_query_apply(&q, UDF_FILE, "sum_bin", NULL);
+
+	uint64_t query_id = 0;
+	status = aerospike_query_background(as, &err, NULL, &q, &query_id);
+
+	assert_int_eq(status, AEROSPIKE_ERR_PARAM);
+	assert_int_eq(err.code, AEROSPIKE_ERR_PARAM);
+
+	as_query_destroy(&q);
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -541,6 +570,7 @@ SUITE(query_background, "aerospike_query_background tests")
 	suite_add(query_operate);
 	suite_add(query_operate_with_select);
 	suite_add(query_operate_expop);
+	suite_add(query_background_ops_and_apply_rejected);
 
 	if (g_has_ttl) {
 		suite_add(query_operate_ttl);

--- a/src/test/aerospike_scan/scan_async.c
+++ b/src/test/aerospike_scan/scan_async.c
@@ -538,6 +538,30 @@ TEST(scan_async_single_node, "scan single node")
 	assert_false(check.failed);
 }
 
+TEST(scan_async_ops_and_apply_rejected, "async scan rejects combined ops and UDF apply")
+{
+	as_error err;
+	as_string str;
+	as_string_init(&str, "bar", false);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_add_write(&ops, "foo", (as_bin_value*)&str);
+
+	as_scan scan;
+	as_scan_init(&scan, NS, SET1);
+	scan.ops = &ops;
+	as_scan_apply_each(&scan, "aerospike_scan_test", "scan_noop", NULL);
+
+	// Validation happens synchronously before any async work is dispatched, so
+	// no monitor/listener wait is needed here.
+	as_status status = aerospike_scan_async(as, &err, NULL, &scan, 0, scan_listener, NULL, 0);
+	as_scan_destroy(&scan);
+
+	assert_int_eq(status, AEROSPIKE_ERR_PARAM);
+	assert_int_eq(err.code, AEROSPIKE_ERR_PARAM);
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -553,4 +577,5 @@ SUITE(scan_async, "Scan Async Tests")
 	suite_add(scan_async_set1_select);
 	suite_add(scan_async_set1_nodata);
 	suite_add(scan_async_single_node);
+	suite_add(scan_async_ops_and_apply_rejected);
 }

--- a/src/test/aerospike_scan/scan_basics.c
+++ b/src/test/aerospike_scan/scan_basics.c
@@ -1199,6 +1199,51 @@ TEST(scan_operate_expop, "scan operate expop")
 	as_exp_destroy(exp);
 }
 
+TEST(scan_background_ops_and_apply_rejected, "background scan rejects combined ops and UDF apply")
+{
+	as_error err;
+	as_string str;
+	as_string_init(&str, "bar", false);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_add_write(&ops, "foo", (as_bin_value*)&str);
+
+	as_scan scan;
+	as_scan_init(&scan, NS, SET2);
+	scan.ops = &ops;
+	as_scan_apply_each(&scan, "aerospike_scan_test", "scan_noop", NULL);
+
+	uint64_t scanid = 0;
+	as_status status = aerospike_scan_background(as, &err, NULL, &scan, &scanid);
+	as_scan_destroy(&scan);
+
+	assert_int_eq(status, AEROSPIKE_ERR_PARAM);
+	assert_int_eq(err.code, AEROSPIKE_ERR_PARAM);
+}
+
+TEST(scan_foreach_ops_and_apply_rejected, "foreach scan rejects combined ops and UDF apply")
+{
+	as_error err;
+	as_string str;
+	as_string_init(&str, "bar", false);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_add_write(&ops, "foo", (as_bin_value*)&str);
+
+	as_scan scan;
+	as_scan_init(&scan, NS, SET2);
+	scan.ops = &ops;
+	as_scan_apply_each(&scan, "aerospike_scan_test", "scan_noop", NULL);
+
+	as_status status = aerospike_scan_foreach(as, &err, NULL, &scan, scan_check_callback, NULL);
+	as_scan_destroy(&scan);
+
+	assert_int_eq(status, AEROSPIKE_ERR_PARAM);
+	assert_int_eq(err.code, AEROSPIKE_ERR_PARAM);
+}
+
 TEST(scan_filter_set_name, "scan filter set_name")
 {
 	scan_check check = {
@@ -1484,6 +1529,8 @@ SUITE(scan_basics, "aerospike_scan basic tests")
 	suite_add(scan_operate_background_reads_and_writes);
 	suite_add(scan_operate_ttl);
 	suite_add(scan_operate_expop);
+	suite_add(scan_background_ops_and_apply_rejected);
+	suite_add(scan_foreach_ops_and_apply_rejected);
 	suite_add(scan_filter_set_name);
 	suite_add(scan_filter_rec_ttl);
 	suite_add(scan_filter_rec_str_key);


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-2479

[CLIENT-2479] Reject combining ops and UDF apply in scan/query at the C client level

## Summary
`as_query`/`as_scan` allowed both regular operations (`ops`) and a UDF (`apply`/`apply_each`) to be set simultaneously. When both were set, only one silently took effect instead of the client rejecting the combination — a data-correctness bug, not just a missing validation message (confirmed via the Python client, see CLIENT-2479; root cause traced to this C client, which every other language binding on it inherits).

Most execution paths already rejected this correctly. Two gaps:
- **Query:** `aerospike_query_background` had no check at all for the combination (only "at least one of ops/apply is required" and "ops must be all-writes").
- **Scan:** no single gap — instead, added the check to the one shared validation hook (`as_scan_validate`) that all 7 scan entry points already route through.

## Changes
- `src/main/aerospike/aerospike_query.c` — `aerospike_query_background`: added `query->ops && query->apply.function[0]` → `AEROSPIKE_ERR_PARAM` ("Cannot combine query operations with aggregation"), matching the check already present in `aerospike_query_foreach`/`_async`/`_partitions_async`.
- `src/main/aerospike/aerospike_scan.c` — `as_scan_validate` (previously an empty stub): added `scan->ops && scan->apply_each.function[0]` → `AEROSPIKE_ERR_PARAM` ("Cannot combine scan operations with a UDF"). Since every scan entry point (`aerospike_scan_background`, `_foreach`, `_node`, `_partitions`, `_async`, `_node_async`, `_partitions_async`) already funnels through this function (directly or via `as_scan_partitions_validate`), this one change covers all of them.

No changes to `aerospike_query_foreach`/`_async`/`_partitions_async` (already correct) or `aerospike_query_partitions` (intentionally stricter — rejects `apply` alone for partition-scoped foreground queries; left untouched).

## Test plan
- [x] `src/test/aerospike_query/query_background.c` — new `query_background_ops_and_apply_rejected`, asserts `AEROSPIKE_ERR_PARAM`.
- [x] `src/test/aerospike_scan/scan_basics.c` — new `scan_background_ops_and_apply_rejected`, `scan_foreach_ops_and_apply_rejected`.
- [x] `src/test/aerospike_scan/scan_async.c` — new `scan_async_ops_and_apply_rejected` (validation is synchronous, no async wait needed).
- [x] Full local suite run (sync + async builds): `query_background` 7/7, `scan_async` 7/7, `config_basics` 8/8 — all new tests pass, zero regressions in any suite touching query/scan/config.

[CLIENT-2479]: https://aerospike.atlassian.net/browse/CLIENT-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ