### PR TITLE
CLIENT-5275: Align C client with recent string ops spec changes

### DIFF
--- a/src/include/aerospike/as_bit_operations.h
+++ b/src/include/aerospike/as_bit_operations.h
@@ -173,7 +173,8 @@ typedef enum {
 	AS_BIT_OP_COUNT = 51,
 	AS_BIT_OP_LSCAN = 52,
 	AS_BIT_OP_RSCAN = 53,
-	AS_BIT_OP_GET_INT = 54
+	AS_BIT_OP_GET_INT = 54,
+	AS_BIT_OP_B64_ENCODE = 55
 } as_bit_op;
 
 /******************************************************************************
@@ -662,6 +663,62 @@ AS_EXTERN bool
 as_operations_bit_get_int(
 	as_operations* ops, const char* name, as_cdt_ctx* ctx, int bit_offset, uint32_t bit_size,
 	bool sign
+	);
+
+/**
+ * Create bit "b64 encode" operation.
+ * Server returns the base64 text of the whole blob bin as a string.
+ * This is the encode direction; as_operations_string_b64_decode() is the decode
+ * direction and takes a string bin back to a blob.
+ * Requires server version 8.1.3 or later.
+ *
+ * @ingroup bit_operations
+ */
+AS_EXTERN bool
+as_operations_bit_b64_encode(as_operations* ops, const char* name, as_cdt_ctx* ctx);
+
+/**
+ * Create bit "b64 encode" operation from a byte offset through the end of the blob.
+ * A negative byte_offset counts back from the end of the blob. Note the span is
+ * expressed in bytes, unlike the bit offsets and sizes other bit read operations take.
+ * Requires server version 8.1.3 or later.
+ *
+ * @ingroup bit_operations
+ */
+AS_EXTERN bool
+as_operations_bit_b64_encode_from(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset
+	);
+
+/**
+ * Create bit "b64 encode" operation on a byte span.
+ * Server returns the base64 text of byte_size bytes of the blob starting at
+ * byte_offset, as a string. A negative byte_offset counts back from the end of
+ * the blob. Note the span is expressed in bytes, unlike the bit offsets and
+ * sizes other bit read operations take.
+ * Requires server version 8.1.3 or later.
+ *
+ * @ingroup bit_operations
+ */
+AS_EXTERN bool
+as_operations_bit_b64_encode_range(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset, int byte_size
+	);
+
+/**
+ * Create bit "b64 encode" operation on a byte span, with byte_size measured from
+ * the end of the blob. When invert_size is true, byte_size counts back from the
+ * blob end rather than forward from byte_offset, so a byte_size of 0 means to the
+ * end of the blob. When false this behaves exactly as
+ * as_operations_bit_b64_encode_range().
+ * Requires server version 8.1.3 or later.
+ *
+ * @ingroup bit_operations
+ */
+AS_EXTERN bool
+as_operations_bit_b64_encode_range_invert(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset, int byte_size,
+	bool invert_size
 	);
 
 #ifdef __cplusplus

--- a/src/include/aerospike/as_exp.h
+++ b/src/include/aerospike/as_exp.h
@@ -2190,6 +2190,11 @@ as_exp_destroy_base64(char* base64)
 		{.op=_AS_EXP_CODE_CALL_VOP_START, .count=1 + __param, .v.ctx=__ctx}, \
 		as_exp_int(__op)
 
+#define _AS_EXP_CDT_LIST_READ_STR \
+		{.op=_AS_EXP_CODE_CALL, .count=5}, \
+		_AS_EXP_VAL_RTYPE(AS_EXP_TYPE_STR), \
+		as_exp_int(_AS_EXP_SYS_CALL_CDT)
+
 /**
  * Create expression that returns list size.
  *
@@ -2201,6 +2206,41 @@ as_exp_destroy_base64(char* base64)
 #define as_exp_list_size(__ctx, __bin) \
 		_AS_EXP_CDT_LIST_READ(AS_EXP_TYPE_AUTO, AS_LIST_RETURN_COUNT, false), \
 		_AS_EXP_LIST_START(__ctx, AS_CDT_OP_LIST_SIZE, 0), \
+		__bin
+
+/**
+ * Create expression that concatenates the string items of a list and returns the
+ * result as a single string, with no separator between items. Every item must be
+ * a string. An empty list yields an empty string.
+ * Requires server version 8.1.3 or later.
+ *
+ * @param __ctx			Optional context path for nested CDT (as_cdt_ctx).
+ * @param __bin			List bin or list value expression.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_list_join(__ctx, __bin) \
+		_AS_EXP_CDT_LIST_READ_STR, \
+		_AS_EXP_LIST_START(__ctx, AS_CDT_OP_LIST_STRING_LIST_JOIN, 0), \
+		__bin
+
+/**
+ * Create expression that concatenates the string items of a list, placing
+ * __separator between consecutive items, and returns the result as a single
+ * string. Every item must be a string. An empty list yields an empty string,
+ * and a single-item list yields that item with no separator applied.
+ * Requires server version 8.1.3 or later.
+ *
+ * @param __ctx			Optional context path for nested CDT (as_cdt_ctx).
+ * @param __separator	Separator string expression.
+ * @param __bin			List bin or list value expression.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_list_join_separator(__ctx, __separator, __bin) \
+		_AS_EXP_CDT_LIST_READ_STR, \
+		_AS_EXP_LIST_START(__ctx, AS_CDT_OP_LIST_STRING_LIST_JOIN, 1), \
+		as_exp_str(__separator), \
 		__bin
 
 /**
@@ -3533,6 +3573,54 @@ as_exp_destroy_base64(char* base64)
 		as_exp_int(__sign ? 1 : 0), \
 		__bin
 
+/**
+ * Create expression that returns the base64 text of the whole blob bin as a string.
+ * Requires server version 8.1.3 or later.
+ *
+ * @param __bin			A blob bin expression to apply this function to.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_bit_b64_encode(__bin) \
+		_AS_EXP_BIT_READ_START(AS_EXP_TYPE_STR, AS_BIT_OP_B64_ENCODE, 0), \
+		__bin
+
+/**
+ * Create expression that returns the base64 text from __byte_offset through the
+ * end of the blob as a string. A negative __byte_offset counts back from the end
+ * of the blob. Note the span is expressed in bytes, unlike the bit offsets and
+ * sizes other bit expressions take.
+ * Requires server version 8.1.3 or later.
+ *
+ * @param __byte_offset	Byte offset into the blob. Negative values count from the end.
+ * @param __bin			A blob bin expression to apply this function to.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_bit_b64_encode_from(__byte_offset, __bin) \
+		_AS_EXP_BIT_READ_START(AS_EXP_TYPE_STR, AS_BIT_OP_B64_ENCODE, 1), \
+		__byte_offset, \
+		__bin
+
+/**
+ * Create expression that returns the base64 text of a byte range of the blob bin
+ * as a string. A negative __byte_offset counts back from the end of the blob.
+ * Note the span is expressed in bytes, unlike the bit offsets and sizes other
+ * bit expressions take.
+ * Requires server version 8.1.3 or later.
+ *
+ * @param __byte_offset	Byte offset into the blob. Negative values count from the end.
+ * @param __byte_size	Number of bytes to encode.
+ * @param __bin			A blob bin expression to apply this function to.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_bit_b64_encode_range(__byte_offset, __byte_size, __bin) \
+		_AS_EXP_BIT_READ_START(AS_EXP_TYPE_STR, AS_BIT_OP_B64_ENCODE, 2), \
+		__byte_offset, \
+		__byte_size, \
+		__bin
+
 //---------------------------------
 // HLL Modify Expressions
 //---------------------------------
@@ -3738,6 +3826,24 @@ as_exp_destroy_base64(char* base64)
 		__bin
 
 //---------------------------------
+// String Expressions
+//---------------------------------
+
+/**
+ * String expressions invoke the string operation module (see @ref string_operations)
+ * inside an expression tree. Each as_exp_string_*() macro mirrors the
+ * corresponding as_operations_string_*() operate API; as_exp_to_string() mirrors
+ * as_operations_to_string().
+ *
+ * Requires server version 8.1.3 or later.
+ *
+ * Unlike operate-level string ops, these macros do not take as_cdt_ctx. To target
+ * a string nested inside a list or map, extract the leaf with
+ * as_exp_list_get_by_index() or as_exp_map_get_by_key() and pass the result as
+ * the operand expression.
+ */
+
+//---------------------------------
 // String Read Expressions
 //---------------------------------
 
@@ -3906,10 +4012,11 @@ as_exp_destroy_base64(char* base64)
 		__bin
 
 /**
- * Create an expression that performs an as_operations_string_is_numeric operation.
+ * Create expression that tests whether __bin contains a valid integer or float
+ * literal. Returns true on match, false otherwise.
  *
  * @param __bin			A bin expression to apply this function to.
- * @return (bool bin) true if the string is a numeric value, false otherwise.
+ * @return (bool expression)
  * @ingroup expression
  */
 #define as_exp_string_is_numeric(__bin) \
@@ -3917,11 +4024,14 @@ as_exp_destroy_base64(char* base64)
 		__bin
 
 /**
- * Create an expression that performs an as_operations_string_is_numeric_type operation.
+ * Create expression that tests whether __bin matches the requested
+ * as_string_numeric_type. This is a spelling check, not "parses as a number of
+ * that type": AS_STRING_NUMERIC_FLOAT requires a `.` followed by a digit, so
+ * `"5"` is false under AS_STRING_NUMERIC_FLOAT even though it parses as a double.
  *
  * @param __numeric_type	The numeric type to filter for.
  * @param __bin			A bin expression to apply this function to.
- * @return (bool bin) true if the string is a numeric value of the type, false otherwise.
+ * @return (bool expression)
  * @ingroup expression
  */
 #define as_exp_string_is_numeric_type(__numeric_type, __bin) \
@@ -4152,6 +4262,22 @@ as_exp_destroy_base64(char* base64)
 		__bin
 
 /**
+ * Create expression that removes codepoints from __start through the end of the
+ * string. This uses the 1-arg wire form; policy flags are not sent. Use
+ * as_exp_string_snip() when non-default policy flags are required.
+ *
+ * @param __policy		The string policy. Ignored on the wire for this overload.
+ * @param __start		First codepoint to remove, inclusive.
+ * @param __bin			A bin expression to apply this function to.
+ * @return (string expression)
+ * @ingroup expression
+ */
+#define as_exp_string_snip_start(__policy, __start, __bin) \
+		_AS_EXP_STRING_MOD_START(AS_STRING_OP_SNIP, 1), \
+		as_exp_int(__start), \
+		__bin
+
+/**
  * Create an expression that performs an as_operations_string_snip operation.
  *
  * @param __policy		The string policy.
@@ -4360,10 +4486,12 @@ as_exp_destroy_base64(char* base64)
 		__bin
 
 /**
- * Create an expression that performs an as_operations_to_string operation.
+ * Create expression that returns the string representation of __bin, where
+ * __bin may be any expression yielding an integer, float, string, boolean, or
+ * blob value. Returns an error for any other source type.
  *
- * @param __bin			A bin expression to apply this function to.
- * @return (string bin) The string in the bin with the value converted to a string.
+ * @param __bin			Operand expression (INT, FLOAT, STR, BOOL, or BLOB).
+ * @return (string expression)
  * @ingroup expression
  */
 #define as_exp_to_string(__bin) \

--- a/src/include/aerospike/as_list_operations.h
+++ b/src/include/aerospike/as_list_operations.h
@@ -251,6 +251,7 @@ typedef enum {
 	AS_CDT_OP_LIST_GET_BY_VALUE_INTERVAL = 25,
 	AS_CDT_OP_LIST_GET_BY_RANK_RANGE = 26,
 	AS_CDT_OP_LIST_GET_BY_VALUE_REL_RANK_RANGE = 27,
+	AS_CDT_OP_LIST_STRING_LIST_JOIN = 28,
 	AS_CDT_OP_LIST_REMOVE_BY_INDEX = 32,
 	AS_CDT_OP_LIST_REMOVE_BY_RANK = 34,
 	AS_CDT_OP_LIST_REMOVE_ALL_BY_VALUE = 35,
@@ -731,6 +732,39 @@ as_operations_list_get_range(
 AS_EXTERN bool
 as_operations_list_get_range_from(
 	as_operations* ops, const char* name, as_cdt_ctx* ctx, int64_t index
+	);
+
+/**
+ * Create list join operation.
+ * Server concatenates the string items of the list bin and returns the result as a
+ * single string, with no separator between items. Every item must be a string;
+ * a non-string item returns AEROSPIKE_ERR_REQUEST_INVALID. An empty list returns an empty
+ * string.
+ * This is the inverse of as_operations_string_split().
+ * Requires server version 8.1.3 or later.
+ *
+ * @ingroup list_operations
+ */
+AS_EXTERN bool
+as_operations_list_join(as_operations* ops, const char* name, as_cdt_ctx* ctx);
+
+/**
+ * Create list join operation with a separator.
+ * Server concatenates the string items of the list bin, placing separator between
+ * consecutive items, and returns the result as a single string. Every item must
+ * be a string; a non-string item returns AEROSPIKE_ERR_REQUEST_INVALID. An empty list
+ * returns an empty string, and a single-item list returns that item with no
+ * separator applied.
+ * This is the inverse of as_operations_string_split_separator().
+ * Requires server version 8.1.3 or later.
+ *
+ * @param separator Separator placed between consecutive items.
+ *
+ * @ingroup list_operations
+ */
+AS_EXTERN bool
+as_operations_list_join_separator(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, const char* separator
 	);
 
 /**

--- a/src/include/aerospike/as_list_operations.h
+++ b/src/include/aerospike/as_list_operations.h
@@ -758,6 +758,9 @@ as_operations_list_join(as_operations* ops, const char* name, as_cdt_ctx* ctx);
  * This is the inverse of as_operations_string_split_separator().
  * Requires server version 8.1.3 or later.
  *
+ * @param ops Operations array.
+ * @param name Name of list bin.
+ * @param ctx Optional path to nested list. If not defined, the top-level list is used.
  * @param separator Separator placed between consecutive items.
  *
  * @ingroup list_operations

--- a/src/include/aerospike/as_string_operations.h
+++ b/src/include/aerospike/as_string_operations.h
@@ -27,7 +27,8 @@
  * Negative indexes count from the end of the string (-1 is the last
  * codepoint). Out-of-bounds indexes are clamped by the server.
  *
- * String operations require server version 8.1.3 or later. When ctx is not
+ * All functions in this module, including as_operations_to_string(), require
+ * server version 8.1.3 or later. When ctx is not NULL and not empty, the
  * NULL and not empty, the operation targets a string nested inside a list or
  * map. The ctx-navigated leaf must already be an Aerospike string; operations
  * on non-string leaves return AEROSPIKE_ERR_BIN_INCOMPATIBLE_TYPE.
@@ -85,7 +86,18 @@ typedef enum as_string_write_flags_e {
 	/** Default. Allow create or update. */
 	AS_STRING_WRITE_FLAGS_DEFAULT = 0,
 
-	/** Update existing values only. */
+	/**
+	 * Create new values only. Valid on insert, overwrite, concat, append,
+	 * prepend, pad_start, pad_end, and repeat. Returns AEROSPIKE_ERR_BIN_EXISTS
+	 * if the bin already exists. Mutually exclusive with
+	 * AS_STRING_WRITE_FLAGS_UPDATE_ONLY. Invalid with a CDT context path.
+	 */
+	AS_STRING_WRITE_FLAGS_CREATE_ONLY = 1,
+
+	/**
+	 * Update existing values only. Mutually exclusive with
+	 * AS_STRING_WRITE_FLAGS_CREATE_ONLY.
+	 */
 	AS_STRING_WRITE_FLAGS_UPDATE_ONLY = 2,
 
 	/**
@@ -114,7 +126,11 @@ typedef enum as_string_numeric_type_e {
 	/** Match only integers. */
 	AS_STRING_NUMERIC_INT = 1,
 
-	/** Match only floating-point numbers. */
+	/**
+	 * Match only floating-point numbers. Stricter than parsing as a double: the
+	 * string must contain a `.` followed by a digit, so `"5"` is false under
+	 * AS_STRING_NUMERIC_FLOAT but true under AS_STRING_NUMERIC_ANY.
+	 */
 	AS_STRING_NUMERIC_FLOAT = 2
 } as_string_numeric_type;
 
@@ -354,7 +370,8 @@ as_operations_string_ends_with(
 
 /**
  * Create string to_integer operation that parses the string as an int64.
- * Returns AEROSPIKE_ERR_PARAMETER if the bin cannot be parsed as an integer.
+ * Returns AEROSPIKE_ERR_OP_NOT_APPLICABLE if the bin cannot be parsed as an
+ * integer.
  *
  * @param ops Operations array.
  * @param name Name of string bin.
@@ -367,7 +384,7 @@ as_operations_string_to_integer(as_operations* ops, const char* name, as_cdt_ctx
 
 /**
  * Create string to_double operation that parses the string as a 64-bit float.
- * Returns AEROSPIKE_ERR_PARAMETER if the bin cannot be parsed as a double.
+ * Returns AEROSPIKE_ERR_OP_NOT_APPLICABLE if the bin cannot be parsed as a double.
  *
  * @param ops Operations array.
  * @param name Name of string bin.
@@ -393,7 +410,7 @@ as_operations_string_byte_length(as_operations* ops, const char* name, as_cdt_ct
 
 /**
  * Create string is_numeric operation that returns true if the bin contains a
- * valid integer or floating-point number.
+ * valid integer or float, false otherwise.
  *
  * @param ops Operations array.
  * @param name Name of string bin.
@@ -405,7 +422,10 @@ AS_EXTERN bool
 as_operations_string_is_numeric(as_operations* ops, const char* name, as_cdt_ctx* ctx);
 
 /**
- * Create string is_numeric operation with a numeric type filter.
+ * Create string is_numeric operation that filters by numeric_type (see
+ * as_string_numeric_type). For example, restrict to integer-only or float-only
+ * validation. AS_STRING_NUMERIC_FLOAT requires a `.` followed by a digit, so
+ * `"5"` is false under AS_STRING_NUMERIC_FLOAT.
  *
  * @param ops Operations array.
  * @param name Name of string bin.
@@ -554,9 +574,9 @@ as_operations_string_insert(
 	);
 
 /**
- * Create string overwrite operation that overwrites codepoints starting at index
- * with value. The result may grow beyond the original length when value extends
- * past the end.
+ * Create string overwrite operation that overwrites codepoints starting at
+ * index with value. The result may grow beyond the original length when value
+ * extends past the end.
  *
  * @param ops Operations array.
  * @param name Name of string bin.
@@ -640,6 +660,25 @@ as_operations_string_append(
 AS_EXTERN bool
 as_operations_string_prepend(
 	as_operations* ops, const char* name, as_cdt_ctx* ctx, as_string_policy* policy, const char* value
+	);
+
+/**
+ * Create string snip operation that removes codepoints from start through the
+ * end of the string. This uses the 1-arg wire form; policy flags are not sent.
+ * Use as_operations_string_snip() when non-default policy flags are required.
+ *
+ * @param ops Operations array.
+ * @param name Name of string bin.
+ * @param ctx Optional path into a string nested inside a list or map.
+ * @param policy String policy. Ignored on the wire for this overload.
+ * @param start First codepoint to remove, inclusive.
+ *
+ * @ingroup string_operations
+*/
+AS_EXTERN bool
+as_operations_string_snip_start(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, as_string_policy* policy,
+	int64_t start
 	);
 
 /**

--- a/src/include/aerospike/as_string_operations.h
+++ b/src/include/aerospike/as_string_operations.h
@@ -29,8 +29,8 @@
  *
  * All functions in this module, including as_operations_to_string(), require
  * server version 8.1.3 or later. When ctx is not NULL and not empty, the
- * NULL and not empty, the operation targets a string nested inside a list or
- * map. The ctx-navigated leaf must already be an Aerospike string; operations
+ * operation targets a string nested inside a list or map. The ctx-navigated
+ * leaf must already be an Aerospike string; operations
  * on non-string leaves return AEROSPIKE_ERR_BIN_INCOMPATIBLE_TYPE.
  *
  * as_operations_to_string() is a top-level conversion operation and does not

--- a/src/include/aerospike/as_subcode.h
+++ b/src/include/aerospike/as_subcode.h
@@ -102,6 +102,12 @@
  */
 #define AS_SUB_PARAM_BIN_COUNT_TOO_LARGE                   5
 
+/**
+ * String op CTX envelope is malformed (SERVER-1483 nested shape).
+ * App use: verify the client emits `[0xFF, ctx_list, [sub_op, args...]]`.
+ */
+#define AS_SUB_PARAM_STRING_CTX_MALFORMED                  8
+
 //----------------------------------------------------------------
 // Subcodes paired with AEROSPIKE_ERR_CLUSTER (AS_ERR_UNAVAILABLE)
 //----------------------------------------------------------------
@@ -288,7 +294,11 @@
  */
 #define AS_SUB_OPNOT_STRING_UTF8_INVALID                   11
 
-/* 12 is reserved for AS_SUB_OPNOT_STRING_REGEX_LIMIT_EXCEEDED. */
+/**
+ * Regex pattern exceeded a server limit for an OP_NOT_APPLICABLE string operation.
+ * App use: simplify the pattern or reduce input size before retry.
+ */
+#define AS_SUB_OPNOT_STRING_REGEX_LIMIT_EXCEEDED           12
 
 /**
  * Base64 input is malformed for an OP_NOT_APPLICABLE string operation.

--- a/src/main/aerospike/as_bit_operations.c
+++ b/src/main/aerospike/as_bit_operations.c
@@ -24,6 +24,7 @@
 //---------------------------------
 
 #define INT_FLAGS_SIGNED 1
+#define READ_SUBFLAG_INVERT_SIZE 1
 
 //---------------------------------
 // Static Functions
@@ -200,6 +201,59 @@ as_operations_bit_get_int(
 	if (sign) {
 		as_pack_uint64(&pk, INT_FLAGS_SIGNED);
 	}
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_BIT_READ);
+}
+
+bool
+as_operations_bit_b64_encode(as_operations* ops, const char* name, as_cdt_ctx* ctx)
+{
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, AS_BIT_OP_B64_ENCODE, 0);
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_BIT_READ);
+}
+
+bool
+as_operations_bit_b64_encode_from(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset
+	)
+{
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, AS_BIT_OP_B64_ENCODE, 1);
+	as_pack_int64(&pk, byte_offset);
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_BIT_READ);
+}
+
+bool
+as_operations_bit_b64_encode_range(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset, int byte_size
+	)
+{
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, AS_BIT_OP_B64_ENCODE, 2);
+	as_pack_int64(&pk, byte_offset);
+	as_pack_int64(&pk, byte_size);
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_BIT_READ);
+}
+
+bool
+as_operations_bit_b64_encode_range_invert(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, int byte_offset, int byte_size,
+	bool invert_size
+	)
+{
+	if (!invert_size) {
+		return as_operations_bit_b64_encode_range(ops, name, ctx, byte_offset, byte_size);
+	}
+
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, AS_BIT_OP_B64_ENCODE, 3);
+	as_pack_int64(&pk, byte_offset);
+	as_pack_int64(&pk, byte_size);
+	as_pack_uint64(&pk, READ_SUBFLAG_INVERT_SIZE);
 	as_cdt_end(&pk);
 	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_BIT_READ);
 }

--- a/src/main/aerospike/as_list_operations.c
+++ b/src/main/aerospike/as_list_operations.c
@@ -47,6 +47,7 @@
 #define GET_BY_VALUE_INTERVAL 25
 #define GET_BY_RANK_RANGE 26
 #define GET_BY_VALUE_REL_RANK_RANGE 27
+#define STRING_LIST_JOIN 28
 #define REMOVE_BY_INDEX 32
 #define REMOVE_BY_RANK 34
 #define REMOVE_ALL_BY_VALUE 35
@@ -582,6 +583,34 @@ as_operations_list_get_range_from(
 	as_packer pk = as_cdt_begin();
 	as_cdt_pack_header(&pk, ctx, GET_RANGE, 1);
 	as_pack_int64(&pk, index);
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_CDT_READ);
+}
+
+bool
+as_operations_list_join(as_operations* ops, const char* name, as_cdt_ctx* ctx)
+{
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, STRING_LIST_JOIN, 0);
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_CDT_READ);
+}
+
+bool
+as_operations_list_join_separator(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, const char* separator
+	)
+{
+	if (! separator) {
+		return false;
+	}
+
+	as_string sep;
+	as_string_init(&sep, (char*)separator, false);
+
+	as_packer pk = as_cdt_begin();
+	as_cdt_pack_header(&pk, ctx, STRING_LIST_JOIN, 1);
+	as_pack_val(&pk, (as_val*)&sep);
 	as_cdt_end(&pk);
 	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_CDT_READ);
 }

--- a/src/main/aerospike/as_string_operations.c
+++ b/src/main/aerospike/as_string_operations.c
@@ -43,15 +43,11 @@ as_string_has_ctx(const as_cdt_ctx* ctx)
 static void
 as_string_pack_header(as_packer* pk, as_cdt_ctx* ctx, uint16_t command, uint32_t count)
 {
-	bool has_ctx = as_string_has_ctx(ctx);
-
-	as_pack_list_header(pk, count + 1 + (has_ctx ? 2 : 0));
-
-	if (has_ctx) {
-		as_pack_uint64(pk, 0xff);
-		as_cdt_ctx_pack(ctx, pk);
+	if (as_string_has_ctx(ctx)) {
+		as_cdt_pack_ctx(pk, ctx);
 	}
 
+	as_pack_list_header(pk, count + 1);
 	as_pack_uint64(pk, command);
 }
 
@@ -460,6 +456,21 @@ as_operations_string_prepend(
 	as_string_pack_header(&pk, ctx, AS_STRING_OP_PREPEND, 2);
 	as_string_pack_value(&pk, value);
 	as_pack_uint64(&pk, as_string_policy_flags(policy));
+	as_cdt_end(&pk);
+	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_STRING_MODIFY);
+}
+
+bool
+as_operations_string_snip_start(
+	as_operations* ops, const char* name, as_cdt_ctx* ctx, as_string_policy* policy,
+	int64_t start
+	)
+{
+	(void)policy;
+
+	as_packer pk = as_cdt_begin();
+	as_string_pack_header(&pk, ctx, AS_STRING_OP_SNIP, 1);
+	as_pack_int64(&pk, start);
 	as_cdt_end(&pk);
 	return as_cdt_add_packed(&pk, ops, name, AS_OPERATOR_STRING_MODIFY);
 }

--- a/src/test/aerospike_bit/bit.c
+++ b/src/test/aerospike_bit/bit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2024 Aerospike, Inc.
+ * Copyright 2008-2026 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.
@@ -17,9 +17,12 @@
 #include <aerospike/aerospike.h>
 #include <aerospike/aerospike_key.h>
 #include <aerospike/as_exp.h>
+#include <aerospike/as_exp_operations.h>
 #include <aerospike/as_bit_operations.h>
 #include <aerospike/as_cluster.h>
 #include <aerospike/as_record.h>
+#include <aerospike/as_string_operations.h>
+#include <aerospike/as_version.h>
 
 #include "../test.h"
 
@@ -36,6 +39,7 @@ extern aerospike* as;
 #define NAMESPACE "test"
 #define SET "test_bit"
 #define BIN_NAME "bitbin"
+#define B64_TXT_BIN "b64txt"
 
 /******************************************************************************
  * TYPES
@@ -48,6 +52,20 @@ extern aerospike* as;
 void example_dump_record(const as_record* p_rec);
 
 as_key REC_KEY;
+
+static bool
+server_supports_bit_b64_encode(void)
+{
+	as_node* node = as_node_get_random(as->cluster);
+
+	if (! node) {
+		return false;
+	}
+
+	bool supported = as_version_compare(&node->version, &as_server_version_8_1_3) >= 0;
+	as_node_release(node);
+	return supported;
+}
 
 static bool
 before(atf_suite* suite)
@@ -1686,6 +1704,132 @@ TEST(bit_filter_call_modify_set_int_sub, "Bit filter call modify set int sub")
 	assert_int_eq(status, AEROSPIKE_OK);
 }
 
+TEST(bit_b64_encode, "Bit B64 Encode")
+{
+	if (! server_supports_bit_b64_encode()) {
+		info("skipping bit b64 encode; requires server >= 8.1.3");
+		return;
+	}
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 120);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	uint8_t bytes[] = {0x01, 0x42, 0x03, 0x04, 0x05};
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_rawp(&rec, BIN_NAME, bytes, sizeof(bytes), false);
+
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_record* prec = NULL;
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode(&ops, BIN_NAME, NULL);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "AUIDBAU=");
+	as_record_destroy(prec);
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode_from(&ops, BIN_NAME, NULL, 1);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "QgMEBQ==");
+	as_record_destroy(prec);
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode_range(&ops, BIN_NAME, NULL, 1, 2);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "QgM=");
+	as_record_destroy(prec);
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode_range_invert(&ops, BIN_NAME, NULL, 1, 0, true);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "QgMEBQ==");
+	as_record_destroy(prec);
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode_range(&ops, BIN_NAME, NULL, -1, 1);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "BQ==");
+	as_record_destroy(prec);
+
+	as_exp_build(encode_exp, as_exp_bit_b64_encode(as_exp_bin_blob(BIN_NAME)));
+	as_exp_build(span_exp,
+		as_exp_bit_b64_encode_range(as_exp_int(1), as_exp_int(2), as_exp_bin_blob(BIN_NAME)));
+
+	as_operations_inita(&ops, 2);
+	as_operations_exp_read(&ops, "whole", encode_exp, AS_EXP_READ_DEFAULT);
+	as_operations_exp_read(&ops, "span", span_exp, AS_EXP_READ_DEFAULT);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	as_exp_destroy(encode_exp);
+	as_exp_destroy(span_exp);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(prec, "whole"), "AUIDBAU=");
+	assert_string_eq(as_record_get_str(prec, "span"), "QgM=");
+	as_record_destroy(prec);
+
+	as_operations_inita(&ops, 1);
+	as_operations_bit_b64_encode(&ops, BIN_NAME, NULL);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_operations_destroy(&ops);
+
+	const char* encoded = as_record_get_str(prec, BIN_NAME);
+	assert_not_null(encoded);
+
+	as_record_inita(&rec, 1);
+	as_record_set_str(&rec, B64_TXT_BIN, encoded);
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	as_record_destroy(&rec);
+	as_record_destroy(prec);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_b64_decode(&ops, B64_TXT_BIN, NULL);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_bytes* decoded = (as_bytes*)as_record_get(prec, B64_TXT_BIN);
+	assert_bytes_eq(decoded->value, decoded->size, bytes, sizeof(bytes));
+	as_record_destroy(prec);
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -1717,6 +1861,7 @@ SUITE(bit, "aerospike bitmap tests")
 	suite_add(bit_filter_call_read_lscan);
 	suite_add(bit_filter_call_read_rscan);
 	suite_add(bit_filter_call_read_get_int);
+	suite_add(bit_b64_encode);
 	suite_add(bit_filter_call_modify_resize);
 	suite_add(bit_filter_call_modify_insert);
 	suite_add(bit_filter_call_modify_remove);

--- a/src/test/aerospike_key/error_detail.c
+++ b/src/test/aerospike_key/error_detail.c
@@ -1640,6 +1640,7 @@ TEST(error_detail_opnot_string_subcodes, "4.12 OP_NOT string subcode constants")
 	assert_int_eq(AS_SUB_OPNOT_STRING_CONVERSION_FAILED, 10);
 	assert_int_eq(AS_SUB_OPNOT_STRING_UTF8_INVALID, 11);
 	assert_int_eq(AS_SUB_OPNOT_STRING_B64_INVALID, 13);
+	assert_int_eq(AS_SUB_PARAM_STRING_CTX_MALFORMED, 8);
 }
 
 // 4.13 Verbosity is applied in read header builder

--- a/src/test/aerospike_key/error_detail_integration.c
+++ b/src/test/aerospike_key/error_detail_integration.c
@@ -603,9 +603,9 @@ TEST(ed_sync_exists_not_found_v2, "5.7.1 exists not found verbosity 2")
 	as_status status = aerospike_key_exists(as, &err, &pr, &key, &rec);
 
 	assert_int_eq(status, AEROSPIKE_ERR_RECORD_NOT_FOUND);
-	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
-	}
+	assert_true(strstr(err.message, "subcode=") == NULL);
+	assert_int_eq(err.subcode, AS_SUB_NONE);
+	assert_true(strlen(err.message) > 0);
 }
 
 // 5.8.1 Delete missing key at verbosity 2
@@ -622,9 +622,9 @@ TEST(ed_sync_delete_not_found_v2, "5.8.1 delete not found verbosity 2")
 	as_status status = aerospike_key_remove(as, &err, &pr, &key);
 
 	assert_int_eq(status, AEROSPIKE_ERR_RECORD_NOT_FOUND);
-	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
-	}
+	assert_true(strstr(err.message, "subcode=") == NULL);
+	assert_int_eq(err.subcode, AS_SUB_NONE);
+	assert_true(strlen(err.message) > 0);
 }
 
 // 5.10.1 Successful write at verbosity 2
@@ -739,6 +739,7 @@ TEST(ed_sync_priority_logic_v2, "5.16.1 server message displaces default format"
 	as_status status = aerospike_key_operate(as, &err, &po, &key, &ops, NULL);
 
 	assert_true(status != AEROSPIKE_OK);
+	assert_true(strstr(err.message, "subcode=") == NULL);
 	if (err.subcode > 0) {
 		// Must NOT be the default format "<addr> AEROSPIKE_ERR_..."
 		assert_true(strstr(err.message, as_error_string(status)) == NULL);
@@ -932,8 +933,9 @@ TEST(ed_sync_cdt_map_create_only, "5.12.1 CDT map create-only violation verbosit
 	as_status status = aerospike_key_operate(as, &err, &po, &key, &ops, NULL);
 
 	assert_true(status != AEROSPIKE_OK);
+	assert_true(strstr(err.message, "subcode=") == NULL);
 	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
+		assert_true(strstr(err.message, as_error_string(status)) == NULL);
 	}
 	as_operations_destroy(&ops);
 }
@@ -957,8 +959,9 @@ TEST(ed_sync_bit_invalid, "5.13.1 bit invalid offset verbosity 2")
 	as_status status = aerospike_key_operate(as, &err, &po, &key, &ops, NULL);
 
 	assert_true(status != AEROSPIKE_OK);
+	assert_true(strstr(err.message, "subcode=") == NULL);
 	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
+		assert_true(strstr(err.message, as_error_string(status)) == NULL);
 	}
 	as_operations_destroy(&ops);
 }
@@ -983,8 +986,9 @@ TEST(ed_sync_hll_invalid, "5.14.1 HLL invalid params verbosity 2")
 	as_status status = aerospike_key_operate(as, &err, &po, &key, &ops, NULL);
 
 	assert_true(status != AEROSPIKE_OK);
+	assert_true(strstr(err.message, "subcode=") == NULL);
 	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
+		assert_true(strstr(err.message, as_error_string(status)) == NULL);
 	}
 	as_operations_destroy(&ops);
 }
@@ -1008,8 +1012,9 @@ TEST(ed_sync_param_ttl_invalid, "5.18.1 param bit offset out of range verbosity 
 	as_status status = aerospike_key_operate(as, &err, &po, &key, &ops, NULL);
 
 	assert_true(status != AEROSPIKE_OK);
+	assert_true(strstr(err.message, "subcode=") == NULL);
 	if (err.subcode > 0) {
-		assert_true(strstr(err.message, "subcode=") != NULL);
+		assert_true(strstr(err.message, as_error_string(status)) == NULL);
 	}
 	as_operations_destroy(&ops);
 }

--- a/src/test/aerospike_list/list_basics.c
+++ b/src/test/aerospike_list/list_basics.c
@@ -21,6 +21,8 @@
 #include <aerospike/aerospike_udf.h>
 
 #include <aerospike/as_arraylist.h>
+#include <aerospike/as_cdt_ctx.h>
+#include <aerospike/as_cluster.h>
 #include <aerospike/as_error.h>
 #include <aerospike/as_exp.h>
 #include <aerospike/as_exp_operations.h>
@@ -28,6 +30,7 @@
 #include <aerospike/as_hashmap_iterator.h>
 #include <aerospike/as_integer.h>
 #include <aerospike/as_list.h>
+#include <aerospike/as_list_operations.h>
 #include <aerospike/as_msgpack.h>
 #include <aerospike/as_operations.h>
 #include <aerospike/as_record.h>
@@ -35,6 +38,7 @@
 #include <aerospike/as_string.h>
 #include <aerospike/as_udf.h>
 #include <aerospike/as_val.h>
+#include <aerospike/as_version.h>
 
 #include "../test.h"
 #include "../util/log_helper.h"
@@ -82,6 +86,20 @@ typedef struct list_order_type_s
  *****************************************************************************/
 
 #define LUA_DIR AS_START_DIR "src/test/lua/"
+
+static bool
+server_supports_list_join(void)
+{
+	as_node* node = as_node_get_random(as->cluster);
+
+	if (! node) {
+		return false;
+	}
+
+	bool supported = as_version_compare(&node->version, &as_server_version_8_1_3) >= 0;
+	as_node_release(node);
+	return supported;
+}
 
 static bool
 load_udf(const char* filename)
@@ -4014,6 +4032,191 @@ TEST(list_check_bin_name_length_handling, "test bin name length handling")
 	as_record_destroy(prec);
 }
 
+TEST(list_join, "List join strings")
+{
+	if (! server_supports_list_join()) {
+		info("skipping list join; requires server >= 8.1.3");
+		return;
+	}
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 9999);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_arraylist list;
+	as_arraylist_init(&list, 3, 0);
+	as_arraylist_append_str(&list, "alpha");
+	as_arraylist_append_str(&list, "beta");
+	as_arraylist_append_str(&list, "gamma");
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_list(&rec, BIN_NAME, (as_list*)&list);
+
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_operations_inita(&ops, 2);
+	as_operations_list_join(&ops, BIN_NAME, NULL);
+	as_operations_list_join_separator(&ops, BIN_NAME, NULL, ", ");
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_bin* results = prec->bins.entries;
+	assert_string_eq(as_string_get((as_string*)results[0].valuep), "alphabetagamma");
+	assert_string_eq(as_string_get((as_string*)results[1].valuep), "alpha, beta, gamma");
+	as_record_destroy(prec);
+
+	as_exp_build(join_exp, as_exp_list_join_separator(NULL, ", ", as_exp_bin_list(BIN_NAME)));
+	as_exp_build(join_no_sep_exp, as_exp_list_join(NULL, as_exp_bin_list(BIN_NAME)));
+
+	as_operations_inita(&ops, 2);
+	as_operations_exp_read(&ops, "joined", join_exp, AS_EXP_READ_DEFAULT);
+	as_operations_exp_read(&ops, "joined_no_sep", join_no_sep_exp, AS_EXP_READ_DEFAULT);
+
+	prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	as_exp_destroy(join_exp);
+	as_exp_destroy(join_no_sep_exp);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(prec, "joined"), "alpha, beta, gamma");
+	assert_string_eq(as_record_get_str(prec, "joined_no_sep"), "alphabetagamma");
+	as_record_destroy(prec);
+}
+
+TEST(list_join_empty, "List join empty list")
+{
+	if (! server_supports_list_join()) {
+		info("skipping list join empty; requires server >= 8.1.3");
+		return;
+	}
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 9998);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_arraylist list;
+	as_arraylist_init(&list, 0, 0);
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_list(&rec, BIN_NAME, (as_list*)&list);
+
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_list_join_separator(&ops, BIN_NAME, NULL, ",");
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "");
+	as_record_destroy(prec);
+}
+
+TEST(list_join_non_string_item_fails, "List join rejects non-string items")
+{
+	if (! server_supports_list_join()) {
+		info("skipping list join non-string item; requires server >= 8.1.3");
+		return;
+	}
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 9997);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_arraylist list;
+	as_arraylist_init(&list, 2, 0);
+	as_arraylist_append_str(&list, "alpha");
+	as_arraylist_append_int64(&list, 7);
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_list(&rec, BIN_NAME, (as_list*)&list);
+
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_list_join(&ops, BIN_NAME, NULL);
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_ERR_REQUEST_INVALID);
+	assert_null(prec);
+}
+
+TEST(list_join_nested, "List join nested list context")
+{
+	if (! server_supports_list_join()) {
+		info("skipping list join nested; requires server >= 8.1.3");
+		return;
+	}
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 9996);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_arraylist inner;
+	as_arraylist_init(&inner, 2, 0);
+	as_arraylist_append_str(&inner, "x");
+	as_arraylist_append_str(&inner, "y");
+
+	as_arraylist outer;
+	as_arraylist_init(&outer, 2, 0);
+	as_arraylist_append_str(&outer, "skip");
+	as_arraylist_append(&outer, (as_val*)&inner);
+
+	as_record rec;
+	as_record_inita(&rec, 1);
+	as_record_set_list(&rec, BIN_NAME, (as_list*)&outer);
+
+	status = aerospike_key_put(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	as_record_destroy(&rec);
+
+	as_cdt_ctx ctx;
+	as_cdt_ctx_inita(&ctx, 1);
+	as_cdt_ctx_add_list_index(&ctx, 1);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_list_join_separator(&ops, BIN_NAME, &ctx, "-");
+
+	as_record* prec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &prec);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(prec, BIN_NAME), "x-y");
+	as_record_destroy(prec);
+}
+
 /******************************************************************************
  * TEST SUITE
  *****************************************************************************/
@@ -4044,6 +4247,10 @@ SUITE(list_basics, "aerospike list basic tests")
 	suite_add(list_create);
 	suite_add(list_exp_mod);
 	suite_add(list_exp_read);
+	suite_add(list_join);
+	suite_add(list_join_empty);
+	suite_add(list_join_non_string_item_fails);
+	suite_add(list_join_nested);
 
 	// Requires Aerospike 5.6.
 	suite_add(exp_returns_list);

--- a/src/test/aerospike_string/string.c
+++ b/src/test/aerospike_string/string.c
@@ -15,6 +15,7 @@
  * the License.
  */
 #include <stdlib.h>
+#include <math.h>
 
 #include <aerospike/aerospike.h>
 #include <aerospike/aerospike_key.h>
@@ -186,6 +187,34 @@ put_invalid_string_key(int64_t id)
 	as_record_destroy(&rec);
 	return status;
 }
+
+static as_status
+operate_string_read(int64_t id, const char* value, as_operations* ops, as_record** rec_out)
+{
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, id);
+
+	as_status status = put_string_key(id, value);
+	if (status != AEROSPIKE_OK) {
+		return status;
+	}
+
+	as_error err;
+	status = aerospike_key_operate(as, &err, NULL, &key, ops, rec_out);
+	return status;
+}
+
+#define assert_string_read_fails(__id, __value, __build_op) \
+	do { \
+		as_operations ops; \
+		as_operations_inita(&ops, 1); \
+		__build_op; \
+		as_record* rec = NULL; \
+		as_status status = operate_string_read(__id, __value, &ops, &rec); \
+		as_operations_destroy(&ops); \
+		assert_int_eq(status, AEROSPIKE_ERR_OP_NOT_APPLICABLE); \
+		assert_null(rec); \
+	} while (0)
 
 //---------------------------------
 // Test Cases
@@ -700,6 +729,65 @@ TEST(string_modify_case_normalize_ops, "string case and normalize modify operati
 	as_record_destroy(rec);
 }
 
+TEST(string_snip_start_ops, "string snip start wire and expression operations")
+{
+	as_operations wire_ops;
+	as_operations_inita(&wire_ops, 1);
+	assert_true(as_operations_string_snip_start(&wire_ops, BIN_NAME, NULL, NULL, 5));
+
+	as_bytes* bytes = (as_bytes*)wire_ops.binops.entries[0].bin.valuep;
+	const uint8_t* wire = as_bytes_get(bytes);
+	assert_int_eq(as_bytes_size(bytes), 3);
+	assert_int_eq(wire[0], 0x92);
+	assert_int_eq(wire[1], AS_STRING_OP_SNIP);
+	assert_int_eq(wire[2], 5);
+	as_operations_destroy(&wire_ops);
+
+	as_operations_inita(&wire_ops, 1);
+	assert_true(as_operations_string_snip_start(&wire_ops, BIN_NAME, NULL, NULL, -6));
+	bytes = (as_bytes*)wire_ops.binops.entries[0].bin.valuep;
+	wire = as_bytes_get(bytes);
+	assert_int_eq(as_bytes_size(bytes), 3);
+	assert_int_eq(wire[0], 0x92);
+	assert_int_eq(wire[1], AS_STRING_OP_SNIP);
+	assert_int_eq(wire[2], 0xfa);
+	as_operations_destroy(&wire_ops);
+
+	assert_int_eq(put_string_key(115, "hello world"), AEROSPIKE_OK);
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 115);
+
+	as_operations ops;
+	as_error err;
+	as_record* rec = NULL;
+	as_status status;
+
+	as_operations_inita(&ops, 2);
+	as_operations_string_snip_start(&ops, BIN_NAME, NULL, NULL, -6);
+	as_operations_add_read(&ops, BIN_NAME);
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_string_get((as_string*)rec->bins.entries[1].valuep), "hello");
+	as_record_destroy(rec);
+
+	assert_int_eq(put_string_key(116, "hello world"), AEROSPIKE_OK);
+	as_key_init_int64(&key, NAMESPACE, SET, 116);
+
+	as_exp_build(snip_exp, as_exp_string_snip_start(NULL, 5, as_exp_bin_str(BIN_NAME)));
+	assert_not_null(snip_exp);
+
+	as_operations_inita(&ops, 1);
+	as_operations_exp_read(&ops, "snip", snip_exp, AS_EXP_READ_DEFAULT);
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	as_exp_destroy(snip_exp);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(rec, "snip"), "hello");
+	as_record_destroy(rec);
+}
+
 TEST(string_modify_snip_concat_ops, "string snip and concat operations")
 {
 	assert_int_eq(put_string_key(110, "hello beautiful world"), AEROSPIKE_OK);
@@ -708,9 +796,8 @@ TEST(string_modify_snip_concat_ops, "string snip and concat operations")
 	as_key_init_int64(&key, NAMESPACE, SET, 110);
 
 	as_operations ops;
-	as_operations_inita(&ops, 4);
-	as_operations_string_snip(&ops, BIN_NAME, NULL, NULL, 5, 15);
-	as_operations_string_snip(&ops, BIN_NAME, NULL, NULL, 5, 11);
+	as_operations_inita(&ops, 3);
+	as_operations_string_snip_start(&ops, BIN_NAME, NULL, NULL, 5);
 	as_operations_string_concat(&ops, BIN_NAME, NULL, NULL, "!");
 	as_operations_add_read(&ops, BIN_NAME);
 
@@ -721,6 +808,25 @@ TEST(string_modify_snip_concat_ops, "string snip and concat operations")
 	assert_int_eq(status, AEROSPIKE_OK);
 
 	as_bin* results = rec->bins.entries;
+	assert_int_eq(rec->bins.size, 3);
+	assert_string_eq(as_string_get((as_string*)results[2].valuep), "hello!");
+	as_record_destroy(rec);
+
+	assert_int_eq(put_string_key(112, "hello beautiful world"), AEROSPIKE_OK);
+	as_key_init_int64(&key, NAMESPACE, SET, 112);
+
+	as_operations_inita(&ops, 4);
+	as_operations_string_snip(&ops, BIN_NAME, NULL, NULL, 5, 15);
+	as_operations_string_snip(&ops, BIN_NAME, NULL, NULL, 5, 11);
+	as_operations_string_concat(&ops, BIN_NAME, NULL, NULL, "!");
+	as_operations_add_read(&ops, BIN_NAME);
+
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	results = rec->bins.entries;
 	assert_int_eq(rec->bins.size, 4);
 	assert_string_eq(as_string_get((as_string*)results[3].valuep), "hello!");
 	as_record_destroy(rec);
@@ -914,9 +1020,9 @@ TEST(string_expression_ops, "string expression operations")
 {
 	assert_int_eq(put_string_key(111, "Hello123World"), AEROSPIKE_OK);
 
-	as_string_policy policy;
-	as_string_policy_init(&policy);
-	as_string_policy_set(&policy, AS_STRING_WRITE_FLAGS_NO_FAIL);
+	as_string_policy no_fail_policy;
+	as_string_policy_init(&no_fail_policy);
+	as_string_policy_set(&no_fail_policy, AS_STRING_WRITE_FLAGS_NO_FAIL);
 
 	as_exp_build(len_exp,
 		as_exp_string_strlen(as_exp_bin_str(BIN_NAME)));
@@ -937,7 +1043,8 @@ TEST(string_expression_ops, "string expression operations")
 
 	as_exp_build(regex_replace_no_fail_exp,
 		as_exp_string_regex_replace(
-			&policy, "[unclosed", "NUM", AS_STRING_REGEX_FLAGS_NONE, as_exp_bin_str(BIN_NAME)));
+			&no_fail_policy, "[unclosed", "NUM", AS_STRING_REGEX_FLAGS_NONE,
+			as_exp_bin_str(BIN_NAME)));
 	assert_not_null(regex_replace_no_fail_exp);
 
 	as_exp_build(append_exp,
@@ -961,7 +1068,8 @@ TEST(string_expression_ops, "string expression operations")
 	as_operations_exp_read(&ops, "upper", upper_exp, AS_EXP_READ_DEFAULT);
 	as_operations_exp_read(&ops, "replace", replace_exp, AS_EXP_READ_DEFAULT);
 	as_operations_exp_read(&ops, "regex_replace", regex_replace_exp, AS_EXP_READ_DEFAULT);
-	as_operations_exp_read(&ops, "regex_replace_no_fail", regex_replace_no_fail_exp, AS_EXP_READ_DEFAULT);
+	as_operations_exp_read(&ops, "regex_no_fail", regex_replace_no_fail_exp,
+			AS_EXP_READ_DEFAULT);
 	as_operations_exp_read(&ops, "append", append_exp, AS_EXP_READ_DEFAULT);
 	as_operations_exp_read(&ops, "prepend", prepend_exp, AS_EXP_READ_DEFAULT);
 	as_operations_exp_read(&ops, "to_string", to_string_exp, AS_EXP_READ_DEFAULT);
@@ -984,7 +1092,9 @@ TEST(string_expression_ops, "string expression operations")
 	assert_string_eq(as_record_get_str(rec, "upper"), "HELLO123WORLD");
 	assert_string_eq(as_record_get_str(rec, "replace"), "Hello-World");
 	assert_string_eq(as_record_get_str(rec, "regex_replace"), "HelloNUMWorld");
-	assert_null(as_record_get(rec, "regex_replace_no_fail"));
+	const char* regex_no_fail = as_record_get_str(rec, "regex_no_fail");
+	assert_not_null(regex_no_fail);
+	assert_string_eq(regex_no_fail, "Hello123World");
 	assert_string_eq(as_record_get_str(rec, "append"), "Hello123World!");
 	assert_string_eq(as_record_get_str(rec, "prepend"), "Say Hello123World");
 	assert_string_eq(as_record_get_str(rec, "to_string"), "42");
@@ -1143,6 +1253,198 @@ TEST(string_to_string_variant_ops, "string to_string variant operations")
 	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
 	as_operations_destroy(&ops);
 	assert_int_eq(status, AEROSPIKE_ERR_BIN_INCOMPATIBLE_TYPE);
+	assert_null(rec);
+}
+
+TEST(string_numeric_conversion_ops, "string numeric conversion semantics")
+{
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 130);
+
+	as_operations ops;
+	as_error err;
+	as_record* rec = NULL;
+	as_status status;
+
+	assert_int_eq(put_string_key(130, "1e5"), AEROSPIKE_OK);
+	as_operations_inita(&ops, 4);
+	as_operations_string_to_double(&ops, BIN_NAME, NULL);
+	as_operations_string_is_numeric(&ops, BIN_NAME, NULL);
+	as_operations_string_is_numeric_type(&ops, BIN_NAME, NULL, AS_STRING_NUMERIC_ANY);
+	as_operations_string_is_numeric_type(&ops, BIN_NAME, NULL, AS_STRING_NUMERIC_FLOAT);
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_bin* results = rec->bins.entries;
+	assert_double_eq(as_double_get((as_double*)results[0].valuep), 100000.0);
+	assert_false(as_boolean_get((as_boolean*)results[1].valuep));
+	assert_false(as_boolean_get((as_boolean*)results[2].valuep));
+	assert_false(as_boolean_get((as_boolean*)results[3].valuep));
+	as_record_destroy(rec);
+
+	assert_string_read_fails(130, " 42", as_operations_string_to_integer(&ops, BIN_NAME, NULL));
+	assert_string_read_fails(130, "0x10", as_operations_string_to_double(&ops, BIN_NAME, NULL));
+	assert_string_read_fails(130, "5.", as_operations_string_to_double(&ops, BIN_NAME, NULL));
+	assert_string_read_fails(130, "nan(0x1)", as_operations_string_to_double(&ops, BIN_NAME, NULL));
+
+	assert_int_eq(put_string_key(130, "inf"), AEROSPIKE_OK);
+	as_operations_inita(&ops, 2);
+	as_operations_string_to_double(&ops, BIN_NAME, NULL);
+	as_operations_string_is_numeric(&ops, BIN_NAME, NULL);
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	results = rec->bins.entries;
+	assert_true(isinf(as_double_get((as_double*)results[0].valuep)));
+	assert_true(as_double_get((as_double*)results[0].valuep) > 0);
+	assert_false(as_boolean_get((as_boolean*)results[1].valuep));
+	as_record_destroy(rec);
+
+	assert_int_eq(put_string_key(130, "3.14"), AEROSPIKE_OK);
+	as_operations_inita(&ops, 1);
+	as_operations_string_is_numeric_type(&ops, BIN_NAME, NULL, AS_STRING_NUMERIC_FLOAT);
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_true(as_boolean_get((as_boolean*)rec->bins.entries[0].valuep));
+	as_record_destroy(rec);
+}
+
+TEST(string_overwrite_index_ops, "string overwrite index semantics")
+{
+	assert_int_eq(put_string_key(131, "abcdef"), AEROSPIKE_OK);
+
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 131);
+
+	as_operations ops;
+	as_error err;
+	as_record* rec = NULL;
+	as_status status;
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_overwrite(&ops, BIN_NAME, NULL, NULL, -2, "XY");
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, NULL);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	status = aerospike_key_get(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(rec, BIN_NAME), "abcdXY");
+	as_record_destroy(rec);
+	rec = NULL;
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_overwrite(&ops, BIN_NAME, NULL, NULL, 100, "x");
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_ERR_REQUEST_INVALID);
+	assert_null(rec);
+}
+
+TEST(string_create_only_policy_ops, "string create only policy operations")
+{
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 140);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_record seed;
+	as_record_inita(&seed, 1);
+	as_record_set_str(&seed, OTHER_BIN, "untouched");
+	status = aerospike_key_put(as, &err, NULL, &key, &seed);
+	as_record_destroy(&seed);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_string_policy create_only;
+	as_string_policy_init(&create_only);
+	as_string_policy_set(&create_only, AS_STRING_WRITE_FLAGS_CREATE_ONLY);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_string_append(&ops, BIN_NAME, NULL, &create_only, "seed");
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, NULL);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_record* rec = NULL;
+	status = aerospike_key_get(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(rec, BIN_NAME), "seed");
+	assert_string_eq(as_record_get_str(rec, OTHER_BIN), "untouched");
+	as_record_destroy(rec);
+
+	assert_int_eq(put_string_key(141, "existing"), AEROSPIKE_OK);
+	as_key_init_int64(&key, NAMESPACE, SET, 141);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_append(&ops, BIN_NAME, NULL, &create_only, "-more");
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_ERR_BIN_EXISTS);
+	assert_null(rec);
+
+	as_string_policy create_only_no_fail;
+	as_string_policy_init(&create_only_no_fail);
+	as_string_policy_set(&create_only_no_fail,
+			AS_STRING_WRITE_FLAGS_CREATE_ONLY | AS_STRING_WRITE_FLAGS_NO_FAIL);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_append(&ops, BIN_NAME, NULL, &create_only_no_fail, "-more");
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, NULL);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	rec = NULL;
+	status = aerospike_key_get(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_string_eq(as_record_get_str(rec, BIN_NAME), "existing");
+	as_record_destroy(rec);
+
+	as_string_policy invalid_flags;
+	as_string_policy_init(&invalid_flags);
+	as_string_policy_set(&invalid_flags,
+			AS_STRING_WRITE_FLAGS_CREATE_ONLY | AS_STRING_WRITE_FLAGS_UPDATE_ONLY);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_append(&ops, BIN_NAME, NULL, &invalid_flags, "x");
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	assert_int_eq(status, AEROSPIKE_ERR_REQUEST_INVALID);
+	assert_null(rec);
+
+	as_arraylist list;
+	as_arraylist_inita(&list, 1);
+	as_arraylist_append_str(&list, "nested");
+
+	as_record put;
+	as_record_inita(&put, 1);
+	as_record_set_list(&put, LIST_BIN, (as_list*)&list);
+	status = aerospike_key_put(as, &err, NULL, &key, &put);
+	as_record_destroy(&put);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_cdt_ctx ctx;
+	as_cdt_ctx_init(&ctx, 1);
+	as_cdt_ctx_add_list_index(&ctx, 0);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_append(&ops, LIST_BIN, &ctx, &create_only, "x");
+	rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+	assert_int_eq(status, AEROSPIKE_ERR_REQUEST_INVALID);
 	assert_null(rec);
 }
 
@@ -1310,6 +1612,76 @@ TEST(string_ctx_ops, "string context operations")
 	as_record_destroy(rec);
 }
 
+TEST(string_ctx_nested_envelope_ops, "string ctx nested wire envelope operations")
+{
+	as_key key;
+	as_key_init_int64(&key, NAMESPACE, SET, 132);
+
+	as_error err;
+	as_status status = aerospike_key_remove(as, &err, NULL, &key);
+	assert_true(status == AEROSPIKE_OK || status == AEROSPIKE_ERR_RECORD_NOT_FOUND);
+
+	as_arraylist list;
+	as_arraylist_inita(&list, 2);
+	as_arraylist_append_str(&list, "read-me");
+	as_arraylist_append_str(&list, "modify-me");
+
+	as_record put;
+	as_record_inita(&put, 1);
+	as_record_set_list(&put, LIST_BIN, (as_list*)&list);
+	status = aerospike_key_put(as, &err, NULL, &key, &put);
+	as_record_destroy(&put);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_cdt_ctx ctx;
+	as_cdt_ctx_init(&ctx, 1);
+	as_cdt_ctx_add_list_index(&ctx, 0);
+
+	as_operations ops;
+	as_operations_inita(&ops, 1);
+	as_operations_string_strlen(&ops, LIST_BIN, &ctx);
+
+	as_record* rec = NULL;
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, &rec);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+	assert_int_eq(status, AEROSPIKE_OK);
+	assert_int_eq(as_integer_get((as_integer*)rec->bins.entries[0].valuep), 7);
+	as_record_destroy(rec);
+
+	as_cdt_ctx_init(&ctx, 1);
+	as_cdt_ctx_add_list_index(&ctx, 1);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_concat(&ops, LIST_BIN, &ctx, NULL, "-suffix");
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, NULL);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_string_policy policy;
+	as_string_policy_init(&policy);
+
+	as_cdt_ctx_init(&ctx, 1);
+	as_cdt_ctx_add_list_index(&ctx, 1);
+
+	as_operations_inita(&ops, 1);
+	as_operations_string_upper(&ops, LIST_BIN, &ctx, &policy);
+	status = aerospike_key_operate(as, &err, NULL, &key, &ops, NULL);
+	as_operations_destroy(&ops);
+	as_cdt_ctx_destroy(&ctx);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	rec = NULL;
+	status = aerospike_key_get(as, &err, NULL, &key, &rec);
+	assert_int_eq(status, AEROSPIKE_OK);
+
+	as_list* out = as_record_get_list(rec, LIST_BIN);
+	assert_string_eq(as_string_get((as_string*)as_list_get(out, 0)), "read-me");
+	assert_string_eq(as_string_get((as_string*)as_list_get(out, 1)), "MODIFY-ME-SUFFIX");
+	as_record_destroy(rec);
+}
+
 SUITE(string, "aerospike string operation tests")
 {
 	suite_before(before);
@@ -1325,7 +1697,9 @@ SUITE(string, "aerospike string operation tests")
 	suite_add(string_policy_ops);
 	suite_add(string_modify_more_ops);
 	suite_add(string_modify_case_normalize_ops);
+	suite_add(string_snip_start_ops);
 	suite_add(string_modify_snip_concat_ops);
+	suite_add(string_create_only_policy_ops);
 	suite_add(string_modify_append_prepend_ops);
 	suite_add(string_modify_append_prepend_unicode_ops);
 	suite_add(string_nested_map_ctx_ops);
@@ -1333,7 +1707,10 @@ SUITE(string, "aerospike string operation tests")
 	suite_add(string_expression_concat_repro);
 	suite_add(string_conversion_unicode_ops);
 	suite_add(string_to_string_variant_ops);
+	suite_add(string_numeric_conversion_ops);
+	suite_add(string_overwrite_index_ops);
 	suite_add(string_error_ops);
 	suite_add(string_invalid_utf8_ops);
 	suite_add(string_ctx_ops);
+	suite_add(string_ctx_nested_envelope_ops);
 }


### PR DESCRIPTION
Jira tickets
[CLIENT-4354](https://aerospike.atlassian.net/browse/CLIENT-4354) — Support for String operations API (parent epic)
[CLIENT-4824](https://aerospike.atlassian.net/browse/CLIENT-4824) — C Client – Implement String Ops
[CLIENT-4955](https://aerospike.atlassian.net/browse/CLIENT-4955) — C Client – append / prepend / regexCompare
[CLIENT-5164](https://aerospike.atlassian.net/browse/CLIENT-5164) — toString expression → EXP_TO_STRING opcode 99
[CLIENT-5275](https://aerospike.atlassian.net/browse/CLIENT-5275) — isNumeric FLOAT doc + conversion error-code docs
[CLIENT-5309](https://aerospike.atlassian.net/browse/CLIENT-5309) — String CTX nested wire shape (SERVER-1483)
[CLIENT-5355](https://aerospike.atlassian.net/browse/CLIENT-5355) — 1-arg snip(start) operate + expression
[CLIENT-5364](https://aerospike.atlassian.net/browse/CLIENT-5364) — Expose CREATE_ONLY string write flag
[CLIENT-5330](https://aerospike.atlassian.net/browse/CLIENT-5330) — list_join (C portion)
[CLIENT-5331](https://aerospike.atlassian.net/browse/CLIENT-5331) — bit_b64_encode (C portion)

[CLIENT-4354]: https://aerospike.atlassian.net/browse/CLIENT-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-4824]: https://aerospike.atlassian.net/browse/CLIENT-4824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-4955]: https://aerospike.atlassian.net/browse/CLIENT-4955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5164]: https://aerospike.atlassian.net/browse/CLIENT-5164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5275]: https://aerospike.atlassian.net/browse/CLIENT-5275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5309]: https://aerospike.atlassian.net/browse/CLIENT-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5355]: https://aerospike.atlassian.net/browse/CLIENT-5355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5364]: https://aerospike.atlassian.net/browse/CLIENT-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5330]: https://aerospike.atlassian.net/browse/CLIENT-5330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-5331]: https://aerospike.atlassian.net/browse/CLIENT-5331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ