### PR TITLE
CLIENT-3434 feat: expose as_op_is_write variable on Windows for Python client to use

### DIFF
--- a/src/main/aerospike/as_operations.c
+++ b/src/main/aerospike/as_operations.c
@@ -29,7 +29,7 @@
 //---------------------------------
 
 // These values must line up with as_operator enum.
-bool as_op_is_write[] = {
+AS_EXTERN extern bool as_op_is_write[] = {
 	false,
 	true,
 	false,


### PR DESCRIPTION
This allows the Python client's `batch_operate()` to determine whether to use the client config's `batch` or `batch_parent_write` policy when setting the default values for a command-level batch policy (e.g an empty dictionary should be populated with values from either of those client config policies depending if there is a write operation or not)